### PR TITLE
refactor: harden annotation storage, canonicalize tag handling

### DIFF
--- a/media/sidebar-webview.js
+++ b/media/sidebar-webview.js
@@ -12,6 +12,7 @@ const vscode = acquireVsCodeApi();
 const state = {
   annotations: [],
   availableTags: [],
+  tagLabels: {},
   filters: {
     status: 'all',
     tag: 'all',
@@ -97,8 +98,8 @@ class AnnotationHandlers {
     }
 
     // Get current tags
-    const currentTags = annotation.tags?.map((t) => (typeof t === 'string' ? t : t.id)) || [];
-    const filteredTags = availableTags.filter((tag) => !currentTags.includes(tag));
+    const currentTags = annotation.tags || [];
+    const filteredTags = availableTags.filter((tag) => !currentTags.includes(tag.id));
 
     if (filteredTags.length === 0) {
       // All tags already added
@@ -208,10 +209,7 @@ function filterAnnotations(annotations, filters) {
     }
 
     if (filters.tag && filters.tag !== 'all') {
-      const hasTag = ann.tags?.some((t) => {
-        const tagId = typeof t === 'string' ? t : t.id;
-        return tagId === filters.tag;
-      });
+      const hasTag = ann.tags?.some((tagId) => tagId === filters.tag);
       if (!hasTag) {
         return false;
       }
@@ -225,13 +223,16 @@ function extractTags(annotations) {
   const tags = new Set();
   annotations.forEach((ann) => {
     if (ann.tags && Array.isArray(ann.tags)) {
-      ann.tags.forEach((t) => {
-        const tagId = typeof t === 'string' ? t : t.id;
+      ann.tags.forEach((tagId) => {
         tags.add(tagId);
       });
     }
   });
   return Array.from(tags).sort();
+}
+
+function getTagLabel(tagId) {
+  return state.tagLabels[tagId] || tagId;
 }
 
 function calculateStats(annotations) {
@@ -250,7 +251,7 @@ function updateTagFilter(filterElement, tags, currentValue) {
   tags.forEach((tag) => {
     const option = document.createElement('option');
     option.value = tag;
-    option.textContent = tag;
+    option.textContent = getTagLabel(tag);
     filterElement.appendChild(option);
   });
 
@@ -325,17 +326,16 @@ function createAnnotationCard(annotation) {
   tagsContainer.className = 'card-tags';
 
   if (annotation.tags && annotation.tags.length > 0) {
-    annotation.tags.forEach((tag) => {
-      const tagId = typeof tag === 'string' ? tag : tag.id;
+    annotation.tags.forEach((tagId) => {
       const tagEl = document.createElement('span');
       tagEl.className = `tag tag-${tagId}`;
-      tagEl.textContent = tagId;
+      tagEl.textContent = getTagLabel(tagId);
 
       // Add remove button
       const removeBtn = document.createElement('button');
       removeBtn.className = 'tag-remove';
       removeBtn.innerHTML = '<i class="codicon codicon-close"></i>';
-      removeBtn.title = `Remove ${tagId} tag`;
+      removeBtn.title = `Remove ${getTagLabel(tagId)} tag`;
       removeBtn.dataset.action = 'removeTag';
       removeBtn.dataset.annotationId = annotation.id;
       removeBtn.dataset.tag = tagId;
@@ -420,15 +420,12 @@ function groupAnnotations(annotations, groupBy) {
       key = parts.length > 1 ? parts[parts.length - 2] : 'Root';
     } else if (groupBy === 'tag') {
       if (ann.tags && ann.tags.length > 0) {
-        const tagId = typeof ann.tags[0] === 'string' ? ann.tags[0] : ann.tags[0].id;
-        key = tagId;
+        key = getTagLabel(ann.tags[0]);
       } else {
         key = 'Untagged';
       }
     } else if (groupBy === 'status') {
       key = ann.resolved ? 'Resolved' : 'Unresolved';
-    } else if (groupBy === 'priority') {
-      key = ann.priority || 'Default';
     }
 
     if (!groups[key]) {
@@ -618,8 +615,9 @@ function handleUpdateAnnotations(annotations) {
 
 function handleTagsUpdated(tags) {
   try {
-    // Store available tags in state for use by tag picker
-    state.availableTags = tags || [];
+    const availableTags = Array.isArray(tags) ? tags : [];
+    state.availableTags = availableTags;
+    state.tagLabels = Object.fromEntries(availableTags.map((tag) => [tag.id, tag.label]));
     updateTagFilter(elements.tagFilter, extractTags(state.annotations), state.filters.tag);
   } catch (error) {
     console.error('[Annotative] Error updating tags:', error);
@@ -710,17 +708,17 @@ function showTagPicker(annotation, availableTags, onSelect) {
   list.innerHTML = '';
 
   // Create tag picker items
-  availableTags.forEach((tagId) => {
+  availableTags.forEach((tag) => {
     const item = document.createElement('button');
     item.className = 'tag-picker-item';
 
     const tagEl = document.createElement('span');
-    tagEl.className = `tag tag-${tagId}`;
-    tagEl.textContent = tagId;
+    tagEl.className = `tag tag-${tag.id}`;
+    tagEl.textContent = tag.label;
 
     item.appendChild(tagEl);
     item.addEventListener('click', () => {
-      onSelect(tagId);
+      onSelect(tag.id);
       hideTagPicker();
     });
 

--- a/src/commands/annotation.ts
+++ b/src/commands/annotation.ts
@@ -4,17 +4,9 @@
  */
 
 import * as vscode from 'vscode';
-import { AnnotationManager } from '../managers';
 import { AnnotationItem } from '../ui';
 import { CommandContext } from './index';
 import { CopilotExporter } from '../copilotExporter';
-
-/**
- * Helper to convert Tag to string
- */
-function tagToString(tag: string | { id: string }): string {
-    return typeof tag === 'string' ? tag : tag.id;
-}
 
 export function registerAnnotationCommands(
     context: vscode.ExtensionContext,
@@ -50,11 +42,15 @@ export function registerAnnotationCommands(
             let selectedTags: string[] = [];
 
             if (customTags.length > 0) {
-                const tagOptions = customTags.map(t => t.name);
-                selectedTags = await vscode.window.showQuickPick(tagOptions, {
+                const tagOptions = customTags.map(tag => ({
+                    label: tag.name,
+                    value: tag.id,
+                }));
+                const selected = await vscode.window.showQuickPick(tagOptions, {
                     placeHolder: 'Select tags (optional)',
                     canPickMany: true
-                }) || [];
+                });
+                selectedTags = selected?.map(tag => tag.value) || [];
             }
 
             // Get color via quick pick
@@ -150,13 +146,16 @@ export function registerAnnotationCommands(
             let selectedTags: string[] = [];
 
             if (customTags.length > 0) {
-                const tagOptions = customTags.map(t => t.name);
+                const tagOptions = customTags.map(tag => ({
+                    label: tag.name,
+                    value: tag.id,
+                }));
                 const tags = await vscode.window.showQuickPick(tagOptions, {
                     placeHolder: 'Select tags (optional)',
                     canPickMany: true
                 });
                 if (tags) {
-                    selectedTags = tags;
+                    selectedTags = tags.map(tag => tag.value);
                 }
             }
 
@@ -249,16 +248,21 @@ export function registerAnnotationCommands(
 
             // Get updated tags via quick pick (multi-select) - user-defined only
             const customTags = annotationManager.getCustomTags();
-            let tagsToUse = annotation.tags?.map((t) => tagToString(t)) || [];
+            const currentTags = annotation.tags || [];
+            let tagsToUse = [...currentTags];
 
             if (customTags.length > 0) {
-                const tagOptions = customTags.map(t => t.name);
+                const tagOptions = customTags.map(tag => ({
+                    label: tag.name,
+                    value: tag.id,
+                    picked: currentTags.includes(tag.id),
+                }));
                 const selectedTags = await vscode.window.showQuickPick(tagOptions, {
                     placeHolder: 'Select tags (optional)',
                     canPickMany: true
                 });
                 if (selectedTags) {
-                    tagsToUse = selectedTags;
+                    tagsToUse = selectedTags.map(tag => tag.value);
                 }
             }
 
@@ -292,7 +296,7 @@ export function registerAnnotationCommands(
 
             // Show details in information message
             const tagsStr = annotation.tags && annotation.tags.length > 0
-                ? annotation.tags.map(t => tagToString(t)).join(', ')
+                ? annotationManager.resolveTagLabels(annotation.tags).join(', ')
                 : 'none';
             const resolvedStr = annotation.resolved ? 'Resolved' : 'Open';
 

--- a/src/commands/bulk.ts
+++ b/src/commands/bulk.ts
@@ -4,16 +4,8 @@
  */
 
 import * as vscode from 'vscode';
-import { AnnotationManager } from '../managers';
 import { AnnotationProvider } from '../ui';
 import { CommandContext } from './index';
-
-/**
- * Helper to convert Tag to string
- */
-function tagToString(tag: string | { id: string }): string {
-    return typeof tag === 'string' ? tag : tag.id;
-}
 
 export function registerBulkCommands(
     context: vscode.ExtensionContext,
@@ -48,7 +40,10 @@ export function registerBulkCommands(
                 return;
             }
 
-            const tagOptions = customTags.map(t => t.name);
+            const tagOptions = customTags.map(tag => ({
+                label: tag.name,
+                value: tag.id,
+            }));
             const newTags = await vscode.window.showQuickPick(tagOptions, {
                 placeHolder: `Add tags to ${selected.length} annotation(s)`,
                 canPickMany: true
@@ -56,8 +51,8 @@ export function registerBulkCommands(
 
             if (newTags && newTags.length > 0) {
                 for (const annotation of selected) {
-                    const updated = new Set((annotation.tags || []).map(t => tagToString(t)));
-                    newTags.forEach(tag => updated.add(tag));
+                    const updated = new Set(annotation.tags || []);
+                    newTags.forEach(tag => updated.add(tag.value));
                     await annotationManager.editAnnotation(
                         annotation.id,
                         annotation.filePath,
@@ -141,12 +136,11 @@ export function registerBulkCommands(
 
             if (selectedColor) {
                 for (const annotation of selected) {
-                    const tagsStr = annotation.tags?.map(t => tagToString(t));
                     await annotationManager.editAnnotation(
                         annotation.id,
                         annotation.filePath,
                         annotation.comment,
-                        tagsStr,
+                        annotation.tags,
                         selectedColor.value
                     );
                 }

--- a/src/commands/filters.ts
+++ b/src/commands/filters.ts
@@ -57,7 +57,7 @@ export function registerFilterCommands(
             const options = [
                 { label: 'All Tags', value: 'all' as const, description: currentTag === 'all' ? '(current)' : '' },
                 ...allTags.map(tag => ({
-                    label: tag,
+                    label: annotationManager.resolveTagLabel(tag),
                     value: tag,
                     description: currentTag === tag ? '(current)' : ''
                 }))
@@ -130,8 +130,7 @@ export function registerFilterCommands(
                 { label: 'By File', value: 'file' as const, description: currentGroupBy === 'file' ? '(current)' : '' },
                 { label: 'By Tag', value: 'tag' as const, description: currentGroupBy === 'tag' ? '(current)' : '' },
                 { label: 'By Status', value: 'status' as const, description: currentGroupBy === 'status' ? '(current)' : '' },
-                { label: 'By Folder', value: 'folder' as const, description: currentGroupBy === 'folder' ? '(current)' : '' },
-                { label: 'By Priority', value: 'priority' as const, description: currentGroupBy === 'priority' ? '(current)' : '' }
+                { label: 'By Folder', value: 'folder' as const, description: currentGroupBy === 'folder' ? '(current)' : '' }
             ];
 
             const selected = await vscode.window.showQuickPick(options, {

--- a/src/commands/sidebar.ts
+++ b/src/commands/sidebar.ts
@@ -38,27 +38,11 @@ export function registerSidebarCommands(
                 return;
             }
 
-            // Ask about migration
-            const migrateChoice = await vscode.window.showQuickPick([
-                { label: 'Create new storage', description: 'Start fresh', value: false },
-                { label: 'Migrate existing', description: 'Copy current annotations', value: true }
-            ], {
-                placeHolder: 'Initialize .annotative folder'
-            });
-
-            if (!migrateChoice) {
-                return;
-            }
-
             try {
-                const created = await annotationManager.initializeProjectStorage(migrateChoice.value);
+                const created = await annotationManager.initializeProjectStorage();
 
                 if (created) {
-                    vscode.window.showInformationMessage(
-                        migrateChoice.value
-                            ? 'Project storage initialized with existing data.'
-                            : 'Project storage initialized.'
-                    );
+                    vscode.window.showInformationMessage('Project storage initialized.');
                 } else {
                     vscode.window.showInformationMessage('Switched to project storage.');
                 }

--- a/src/commands/tags.ts
+++ b/src/commands/tags.ts
@@ -7,13 +7,6 @@ import * as vscode from 'vscode';
 import { AnnotationItem } from '../ui';
 import { CommandContext } from './index';
 
-/**
- * Helper to convert Tag to string
- */
-function tagToString(tag: string | { id: string }): string {
-    return typeof tag === 'string' ? tag : tag.id;
-}
-
 export function registerTagCommands(
     context: vscode.ExtensionContext,
     cmdContext: CommandContext
@@ -41,7 +34,7 @@ export function registerTagCommands(
             }
 
             // Filter out tags already on the annotation
-            const currentTags = annotation.tags?.map((t) => tagToString(t)) || [];
+            const currentTags = annotation.tags || [];
             const availableTags = customTags.filter(tag => !currentTags.includes(tag.id));
 
             if (availableTags.length === 0) {
@@ -85,7 +78,7 @@ export function registerTagCommands(
             const annotation = item.annotation;
 
             // Get current tags
-            const currentTags = annotation.tags?.map((t) => tagToString(t)) || [];
+            const currentTags = annotation.tags || [];
 
             if (currentTags.length === 0) {
                 vscode.window.showInformationMessage('No tags to remove.');
@@ -95,9 +88,16 @@ export function registerTagCommands(
             // If tag not specified, let user select which tag to remove
             let selectedTag = tagToRemove;
             if (!selectedTag) {
-                selectedTag = await vscode.window.showQuickPick(currentTags, {
-                    placeHolder: 'Select tag to remove'
-                });
+                const selected = await vscode.window.showQuickPick(
+                    currentTags.map(tagId => ({
+                        label: annotationManager.resolveTagLabel(tagId),
+                        value: tagId,
+                    })),
+                    {
+                        placeHolder: 'Select tag to remove'
+                    }
+                );
+                selectedTag = selected?.value;
             }
 
             if (!selectedTag) {
@@ -115,7 +115,7 @@ export function registerTagCommands(
             );
 
             sidebarWebview.refreshAnnotations();
-            vscode.window.showInformationMessage(`Tag removed: ${selectedTag}`);
+            vscode.window.showInformationMessage(`Tag removed: ${annotationManager.resolveTagLabel(selectedTag)}`);
         }
     );
 
@@ -139,7 +139,12 @@ export function registerTagCommands(
                 return;
             }
 
-            const tagOptions = customTags.map(t => t.name);
+            const currentTags = annotation.tags || [];
+            const tagOptions = customTags.map(tag => ({
+                label: tag.name,
+                value: tag.id,
+                picked: currentTags.includes(tag.id),
+            }));
 
             // Let user select tags (multi-select)
             const selectedTags = await vscode.window.showQuickPick(tagOptions, {
@@ -156,7 +161,7 @@ export function registerTagCommands(
                 annotation.id,
                 annotation.filePath,
                 annotation.comment,
-                selectedTags,
+                selectedTags.map(tag => tag.value),
                 annotation.color
             );
 

--- a/src/managers/annotationExporter.ts
+++ b/src/managers/annotationExporter.ts
@@ -5,7 +5,10 @@ import { Annotation, ExportData } from '../types';
  * Export and utility functions for annotations
  */
 export class AnnotationExporter {
-    constructor(private annotations: Map<string, Annotation[]>) {}
+    constructor(
+        private annotations: Map<string, Annotation[]>,
+        private resolveTagLabels: (tagIds?: readonly string[]) => string[] = (tagIds) => [...(tagIds || [])]
+    ) {}
 
     /**
      * Export all annotations
@@ -59,7 +62,7 @@ export class AnnotationExporter {
                 markdown += `**Comment:**\n${annotation.comment}\n\n`;
 
                 if (annotation.tags && annotation.tags.length > 0) {
-                    markdown += `**Tags:** ${annotation.tags.join(', ')}\n\n`;
+                    markdown += `**Tags:** ${this.resolveTagLabels(annotation.tags).join(', ')}\n\n`;
                 }
 
                 markdown += '---\n\n';
@@ -95,8 +98,7 @@ export class AnnotationExporter {
         this.annotations.forEach(fileAnnotations => {
             fileAnnotations.forEach(annotation => {
                 if (annotation.tags) {
-                    annotation.tags.forEach(tag => {
-                        const tagId = typeof tag === 'string' ? tag : tag.id;
+                    annotation.tags.forEach(tagId => {
                         tagSet.add(tagId);
                     });
                 }

--- a/src/managers/annotationManager.ts
+++ b/src/managers/annotationManager.ts
@@ -1,5 +1,15 @@
 import * as vscode from 'vscode';
-import { Annotation, AnnotationTag, TagCategory, TagMetadata, AnnotationStatistics, TagSuggestion, ExportData } from '../types';
+import {
+    Annotation,
+    AnnotationStatistics,
+    AnnotationTag,
+    AnnotationTagOption,
+    ExportData,
+    TagCategory,
+    TagMetadata,
+    TagPriority,
+    TagSuggestion,
+} from '../types';
 import { TagManager } from '../tags';
 import { AnnotationCRUD } from './annotationCRUD';
 import { AnnotationDecorations } from './annotationDecorations';
@@ -7,8 +17,7 @@ import { AnnotationStorageManager } from './annotationStorage';
 import { AnnotationExporter } from './annotationExporter';
 
 /**
- * Main annotation manager - orchestrates all annotation operations
- * Delegates to specialized modules for specific responsibilities
+ * Main annotation manager - orchestrates all annotation operations.
  */
 export class AnnotationManager {
     private annotations: Map<string, Annotation[]> = new Map();
@@ -25,20 +34,20 @@ export class AnnotationManager {
         this.decorations = new AnnotationDecorations();
         this.storage = new AnnotationStorageManager(this.annotations, context);
         this.crud = new AnnotationCRUD(this.annotations, this.decorations, this.storage);
-        this.exporter = new AnnotationExporter(this.annotations);
+        this.exporter = new AnnotationExporter(this.annotations, (tagIds) => this.resolveTagLabels(tagIds));
 
-        this.initialize();
+        void this.initialize();
     }
 
-    /**
-     * Initialize manager
-     */
     private async initialize(): Promise<void> {
-        await this.storage.loadAnnotations();
-        this.loadCustomTags();
-    }
+        await this.loadCustomTags();
+        const annotationLoad = await this.storage.loadAnnotations();
+        const migratedAnnotations = this.normalizeLoadedAnnotations();
 
-    // ============== Tag Management ==============
+        if (annotationLoad.needsSave || migratedAnnotations) {
+            await this.storage.saveAnnotations();
+        }
+    }
 
     getTagManager(): TagManager {
         return this.tagManager;
@@ -50,6 +59,41 @@ export class AnnotationManager {
 
     getCustomTags(): AnnotationTag[] {
         return this.tagManager.getCustomTags();
+    }
+
+    getTagOptions(): AnnotationTagOption[] {
+        return this.tagManager
+            .getAllTags()
+            .map(tag => ({
+                id: tag.id,
+                label: tag.name,
+                color: tag.metadata?.color,
+                priority: tag.metadata?.priority,
+            }))
+            .sort((left, right) => left.label.localeCompare(right.label));
+    }
+
+    resolveTagLabel(tagId: string): string {
+        return this.tagManager.getTag(tagId)?.name || tagId;
+    }
+
+    resolveTagLabels(tagIds?: readonly string[]): string[] {
+        if (!tagIds || tagIds.length === 0) {
+            return [];
+        }
+
+        return tagIds.map(tagId => this.resolveTagLabel(tagId));
+    }
+
+    getAnnotationPriority(annotation: Annotation): TagPriority | undefined {
+        const priorityOrder: TagPriority[] = ['critical', 'high', 'medium', 'low'];
+        const priorities = (annotation.tags || [])
+            .map(tagId => this.tagManager.getTagPriority(tagId))
+            .filter((priority): priority is TagPriority =>
+                priority === 'critical' || priority === 'high' || priority === 'medium' || priority === 'low'
+            );
+
+        return priorityOrder.find(priority => priorities.includes(priority));
     }
 
     async createCustomTag(name: string, category: TagCategory, metadata?: TagMetadata): Promise<AnnotationTag> {
@@ -77,8 +121,6 @@ export class AnnotationManager {
     getTagSuggestions(comment: string): TagSuggestion[] {
         return this.tagManager.suggestTagsFromComment(comment);
     }
-
-    // ============== CRUD Operations ==============
 
     async addAnnotation(
         editor: vscode.TextEditor,
@@ -147,27 +189,14 @@ export class AnnotationManager {
         return result;
     }
 
-    // ============== Query Operations ==============
-
-    /**
-     * Get all tags used in annotations
-     */
     getAllTags(): string[] {
-        // Get tags used in annotations
         const usedTags = this.exporter.getAllTags();
-
-        // Get all preset and custom tag IDs
-        const presetTagIds = this.tagManager.getPresetTags().map(t => t.id);
-        const customTagIds = this.tagManager.getCustomTags().map(t => t.id);
-
-        // Combine and deduplicate
+        const presetTagIds = this.tagManager.getPresetTags().map(tag => tag.id);
+        const customTagIds = this.tagManager.getCustomTags().map(tag => tag.id);
         const allTags = new Set([...usedTags, ...presetTagIds, ...customTagIds]);
         return Array.from(allTags).sort();
     }
 
-    /**
-     * Get only tags that are used in current annotations
-     */
     getUsedTags(): string[] {
         return this.exporter.getAllTags();
     }
@@ -184,14 +213,10 @@ export class AnnotationManager {
         return this.exporter.getStatistics();
     }
 
-    // ============== Decoration & Styling ==============
-
     updateDecorations(editor: vscode.TextEditor): void {
         const fileAnnotations = this.exporter.getAnnotationsForFile(editor.document.uri.fsPath);
         this.decorations.updateDecorations(editor, fileAnnotations);
     }
-
-    // ============== Export & Import ==============
 
     async exportAnnotations(): Promise<ExportData> {
         return this.exporter.exportAnnotations();
@@ -201,50 +226,40 @@ export class AnnotationManager {
         return this.exporter.exportToMarkdown();
     }
 
-    // ============== Project Storage ==============
-
-    /**
-     * Check if project-based storage is active
-     */
     isProjectStorageActive(): boolean {
         return this.storage.isProjectStorageActive();
     }
 
-    /**
-     * Get the current storage directory
-     */
     getStorageDirectory(): string {
         return this.storage.getStorageDirectory();
     }
 
-    /**
-     * Initialize project-based storage (.annotative folder)
-     */
-    async initializeProjectStorage(migrateExisting: boolean = false): Promise<boolean> {
-        const result = await this.storage.initializeProjectStorage(migrateExisting);
-
-        // Reload annotations and tags from the new location
-        await this.storage.loadAnnotations();
+    async initializeProjectStorage(): Promise<boolean> {
+        const result = await this.storage.initializeProjectStorage();
         await this.loadCustomTags();
+        const annotationLoad = await this.storage.loadAnnotations();
+        const migratedAnnotations = this.normalizeLoadedAnnotations();
+        if (annotationLoad.needsSave || migratedAnnotations) {
+            await this.storage.saveAnnotations();
+        }
 
         this.notifyAnnotationsChanged();
         return result;
     }
 
-    /**
-     * Refresh storage detection
-     */
     refreshStorageDetection(): void {
         this.storage.refreshStorageDetection();
     }
 
-    // ============== Persistence ==============
-
     private async loadCustomTags(): Promise<void> {
         try {
-            const customTags = await this.storage.loadCustomTags();
-            if (customTags && customTags.length > 0) {
-                this.tagManager.importCustomTags(customTags);
+            const loaded = await this.storage.loadCustomTags();
+            if (loaded.tags.length > 0) {
+                this.tagManager.importCustomTags(loaded.tags);
+            }
+
+            if (loaded.needsSave) {
+                await this.saveCustomTags();
             }
         } catch (error) {
             console.error('Failed to load custom tags:', error);
@@ -260,17 +275,53 @@ export class AnnotationManager {
         }
     }
 
-    /**
-     * Notify listeners that annotations have changed
-     */
+    private normalizeLoadedAnnotations(): boolean {
+        const allTags = this.tagManager.getAllTags();
+        const tagsById = new Map(allTags.map(tag => [tag.id.toLowerCase(), tag.id]));
+        const tagsByName = new Map(allTags.map(tag => [tag.name.toLowerCase(), tag.id]));
+        let changed = false;
+
+        this.annotations.forEach(fileAnnotations => {
+            fileAnnotations.forEach(annotation => {
+                const nextTags: string[] = [];
+
+                (annotation.tags || []).forEach(rawTagId => {
+                    const normalizedInput = rawTagId.trim();
+                    if (!normalizedInput) {
+                        changed = true;
+                        return;
+                    }
+
+                    const lookupKey = normalizedInput.toLowerCase();
+                    const resolvedId = tagsById.get(lookupKey) || tagsByName.get(lookupKey) || normalizedInput;
+                    if (resolvedId !== rawTagId) {
+                        changed = true;
+                    }
+
+                    if (!nextTags.includes(resolvedId)) {
+                        nextTags.push(resolvedId);
+                    } else {
+                        changed = true;
+                    }
+                });
+
+                if ((annotation.tags || []).length !== nextTags.length) {
+                    changed = true;
+                }
+
+                annotation.tags = nextTags;
+            });
+        });
+
+        return changed;
+    }
+
     private notifyAnnotationsChanged(): void {
         this.onDidChangeAnnotationsEmitter.fire();
     }
 
-    /**
-     * Dispose resources
-     */
     dispose(): void {
+        void this.context;
         this.decorations.dispose();
         this.onDidChangeAnnotationsEmitter.dispose();
     }

--- a/src/managers/annotationStorage.ts
+++ b/src/managers/annotationStorage.ts
@@ -1,110 +1,113 @@
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
 import * as vscode from 'vscode';
-import { Annotation, AnnotationStorage as IAnnotationStorage, AnnotationTag } from '../types';
+import {
+    Annotation,
+    AnnotationStorageFile,
+    AnnotationTag,
+    StoredAnnotation,
+    TagPriority,
+    TagStorageFile,
+} from '../types';
+
+const STORAGE_SCHEMA_VERSION = 1;
+
+export interface LoadAnnotationsResult {
+    needsSave: boolean;
+}
+
+export interface LoadCustomTagsResult {
+    tags: AnnotationTag[];
+    needsSave: boolean;
+}
+
+interface ParsedAnnotationsPayload {
+    workspaceAnnotations: Record<string, StoredAnnotation[]>;
+    needsSave: boolean;
+}
+
+interface ParsedCustomTagsPayload {
+    customTags: AnnotationTag[];
+    needsSave: boolean;
+}
 
 /**
- * Handles persistence of annotations and custom tags
- * Uses project-scoped storage (.annotative folder) exclusively
- * Each workspace has isolated annotation data
+ * Handles persistence of annotations and custom tags.
+ * Uses project-scoped storage (.annotative folder) exclusively.
  */
 export class AnnotationStorageManager {
-    private storageFilePath: string;
-    private customTagsPath: string;
+    private storageFilePath = '';
+    private customTagsPath = '';
     private projectStorageDir: string | undefined;
 
     constructor(
         private annotations: Map<string, Annotation[]>,
         context: vscode.ExtensionContext
     ) {
-        // Initialize paths - will be set properly when project storage is created
-        this.storageFilePath = '';
-        this.customTagsPath = '';
-
-        // Check for existing project storage
+        void context;
         this.detectProjectStorage();
     }
 
-    /**
-     * Detect if project-based storage exists (.annotative folder in workspace root)
-     */
     private detectProjectStorage(): void {
         const workspaceFolders = vscode.workspace.workspaceFolders;
-        if (workspaceFolders && workspaceFolders.length > 0) {
-            const workspaceRoot = workspaceFolders[0].uri.fsPath;
-            const annotativeDir = path.join(workspaceRoot, '.annotative');
-
-            if (fs.existsSync(annotativeDir)) {
-                this.projectStorageDir = annotativeDir;
-                this.storageFilePath = path.join(annotativeDir, 'annotations.json');
-                this.customTagsPath = path.join(annotativeDir, 'customTags.json');
-            }
-        }
-    }
-
-    /**
-     * Check if project storage is active
-     */
-    isProjectStorageActive(): boolean {
-        return !!this.projectStorageDir;
-    }
-
-    /**
-     * Get the current storage directory path
-     */
-    getStorageDirectory(): string {
-        return this.projectStorageDir || '';
-    }
-
-    /**
-     * Ensure project storage exists - creates .annotative folder if needed
-     * Called automatically when first annotation is added
-     */
-    async ensureProjectStorage(): Promise<void> {
-        if (this.projectStorageDir) {
-            return; // Already initialized
-        }
-
-        const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders || workspaceFolders.length === 0) {
-            throw new Error('No workspace folder open'); // Cannot create project storage
+            return;
         }
 
-        const workspaceRoot = workspaceFolders[0].uri.fsPath;
-        const annotativeDir = path.join(workspaceRoot, '.annotative');
-
-        // Create the directory
+        const annotativeDir = path.join(workspaceFolders[0].uri.fsPath, '.annotative');
         if (!fs.existsSync(annotativeDir)) {
-            fs.mkdirSync(annotativeDir, { recursive: true });
-
-            // Create a README to explain the folder purpose
-            const readmePath = path.join(annotativeDir, 'README.md');
-            const readmeContent = `# Annotative Storage\n\nThis folder contains your project's annotations and custom tags.\n\n## Version Control\n\n**Recommended:** Include this folder in version control to share annotations with your team.\n\n\`\`\`bash\ngit add .annotative/\ngit commit -m "Add annotations"\n\`\`\`\n\n**Private annotations:** Add \`.annotative/\` to your project's \`.gitignore\` file.\n\n## Files\n\n- \`annotations.json\` - All annotations in this project\n- \`customTags.json\` - User-defined tag definitions\n`;
-            fs.writeFileSync(readmePath, readmeContent, 'utf-8');
+            return;
         }
 
-        // Set paths
         this.projectStorageDir = annotativeDir;
         this.storageFilePath = path.join(annotativeDir, 'annotations.json');
         this.customTagsPath = path.join(annotativeDir, 'customTags.json');
     }
 
-    /**
-     * Initialize project-based storage (.annotative folder)
-     * Returns true if successfully created, false if already exists
-     * @deprecated Use ensureProjectStorage() instead - storage is now auto-created
-     */
-    async initializeProjectStorage(migrateExisting: boolean = false): Promise<boolean> {
-        // Capture whether the storage file existed before initialization
-        const existedBefore = this.storageFilePath && fs.existsSync(this.storageFilePath);
-        await this.ensureProjectStorage();
-        // Return true only if storage did not exist before but exists after ensuring
-        return !existedBefore && fs.existsSync(this.storageFilePath);
+    isProjectStorageActive(): boolean {
+        return !!this.projectStorageDir;
     }
 
-    /**
-     * Refresh storage detection (useful after folder changes)
-     */
+    getStorageDirectory(): string {
+        return this.projectStorageDir || '';
+    }
+
+    async ensureProjectStorage(): Promise<void> {
+        if (this.projectStorageDir) {
+            return;
+        }
+
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders || workspaceFolders.length === 0) {
+            throw new Error('No workspace folder open');
+        }
+
+        const annotativeDir = path.join(workspaceFolders[0].uri.fsPath, '.annotative');
+        if (!fs.existsSync(annotativeDir)) {
+            await fs.promises.mkdir(annotativeDir, { recursive: true });
+
+            const readmePath = path.join(annotativeDir, 'README.md');
+            const readmeContent = `# Annotative Storage\n\nThis folder contains your project's annotations and custom tags.\n\n## Version Control\n\n**Recommended:** Include this folder in version control to share annotations with your team.\n\n\`\`\`bash\ngit add .annotative/\ngit commit -m "Add annotations"\n\`\`\`\n\n**Private annotations:** Add \`.annotative/\` to your project's \`.gitignore\` file.\n\n## Files\n\n- \`annotations.json\` - All annotations in this project\n- \`customTags.json\` - User-defined tag definitions\n`;
+            await fs.promises.writeFile(readmePath, readmeContent, 'utf-8');
+        }
+
+        this.projectStorageDir = annotativeDir;
+        this.storageFilePath = path.join(annotativeDir, 'annotations.json');
+        this.customTagsPath = path.join(annotativeDir, 'customTags.json');
+    }
+
+    async initializeProjectStorage(): Promise<boolean> {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders || workspaceFolders.length === 0) {
+            throw new Error('No workspace folder open');
+        }
+
+        const annotativeDir = path.join(workspaceFolders[0].uri.fsPath, '.annotative');
+        const existedBefore = fs.existsSync(annotativeDir);
+        await this.ensureProjectStorage();
+        return !existedBefore && !!this.projectStorageDir;
+    }
+
     refreshStorageDetection(): void {
         this.projectStorageDir = undefined;
         this.storageFilePath = '';
@@ -112,80 +115,253 @@ export class AnnotationStorageManager {
         this.detectProjectStorage();
     }
 
-    /**
-     * Load annotations from storage
-     * Only loads if project storage exists
-     */
-    async loadAnnotations(): Promise<void> {
+    async loadAnnotations(): Promise<LoadAnnotationsResult> {
         try {
             if (!this.storageFilePath || !fs.existsSync(this.storageFilePath)) {
-                return;
+                return { needsSave: false };
             }
 
-            const data = fs.readFileSync(this.storageFilePath, 'utf-8');
-            const storage: { workspaceAnnotations: { [key: string]: Annotation[] } } = JSON.parse(data);
+            const data = await fs.promises.readFile(this.storageFilePath, 'utf-8');
+            const parsed = this.parseAnnotationStorage(JSON.parse(data));
 
             this.annotations.clear();
-            Object.entries(storage.workspaceAnnotations).forEach(([filePath, annotations]) => {
-                const normalizedAnnotations = annotations.map(ann => ({
-                    ...ann,
-                    timestamp: new Date(ann.timestamp as any)
-                }));
-                this.annotations.set(filePath, normalizedAnnotations);
+            Object.entries(parsed.workspaceAnnotations).forEach(([filePath, annotations]) => {
+                this.annotations.set(
+                    filePath,
+                    annotations.map(annotation => this.deserializeAnnotation(filePath, annotation))
+                );
             });
+
+            return { needsSave: parsed.needsSave };
         } catch (error) {
             console.error('Failed to load annotations:', error);
+            await this.recoverCorruptFile(this.storageFilePath, 'annotations');
+            this.annotations.clear();
+            return { needsSave: false };
         }
     }
 
-    /**
-     * Save annotations to storage
-     * Auto-creates project storage if it doesn't exist
-     */
     async saveAnnotations(): Promise<void> {
         try {
-            // Ensure project storage exists
             await this.ensureProjectStorage();
 
-            const storage: IAnnotationStorage = {
-                workspaceAnnotations: Object.fromEntries(this.annotations)
+            const storage: AnnotationStorageFile = {
+                schemaVersion: STORAGE_SCHEMA_VERSION,
+                workspaceAnnotations: Object.fromEntries(
+                    Array.from(this.annotations.entries()).map(([filePath, annotations]) => [
+                        filePath,
+                        annotations.map(annotation => this.serializeAnnotation(annotation))
+                    ])
+                )
             };
 
-            fs.writeFileSync(this.storageFilePath, JSON.stringify(storage, null, 2));
+            await this.writeJsonAtomically(this.storageFilePath, storage);
         } catch (error) {
             console.error('Failed to save annotations:', error);
             vscode.window.showErrorMessage('Failed to save annotations');
         }
     }
 
-    /**
-     * Load custom tags from storage
-     */
-    async loadCustomTags(): Promise<AnnotationTag[]> {
+    async loadCustomTags(): Promise<LoadCustomTagsResult> {
         try {
             if (this.customTagsPath && fs.existsSync(this.customTagsPath)) {
-                const data = fs.readFileSync(this.customTagsPath, 'utf-8');
-                return JSON.parse(data);
+                const data = await fs.promises.readFile(this.customTagsPath, 'utf-8');
+                const parsed = this.parseCustomTagsStorage(JSON.parse(data));
+                return {
+                    tags: parsed.customTags,
+                    needsSave: parsed.needsSave,
+                };
             }
         } catch (error) {
             console.error('Failed to load custom tags:', error);
+            await this.recoverCorruptFile(this.customTagsPath, 'custom tags');
         }
-        return [];
+
+        return { tags: [], needsSave: false };
     }
 
-    /**
-     * Save custom tags to storage
-     * Auto-creates project storage if it doesn't exist
-     */
     async saveCustomTags(tags: AnnotationTag[]): Promise<void> {
         try {
-            // Ensure project storage exists
             await this.ensureProjectStorage();
 
-            fs.writeFileSync(this.customTagsPath, JSON.stringify(tags, null, 2));
+            const storage: TagStorageFile = {
+                schemaVersion: STORAGE_SCHEMA_VERSION,
+                customTags: tags,
+            };
+
+            await this.writeJsonAtomically(this.customTagsPath, storage);
         } catch (error) {
             console.error('Failed to save custom tags:', error);
             vscode.window.showErrorMessage('Failed to save custom tags');
         }
+    }
+
+    private serializeAnnotation(annotation: Annotation): StoredAnnotation {
+        return {
+            ...annotation,
+            range: {
+                start: {
+                    line: annotation.range.start.line,
+                    character: annotation.range.start.character,
+                },
+                end: {
+                    line: annotation.range.end.line,
+                    character: annotation.range.end.character,
+                },
+            },
+            timestamp: annotation.timestamp.toISOString(),
+            tags: annotation.tags ? [...annotation.tags] : undefined,
+        };
+    }
+
+    private deserializeAnnotation(filePath: string, annotation: StoredAnnotation): Annotation {
+        const start = annotation.range?.start ?? { line: 0, character: 0 };
+        const end = annotation.range?.end ?? start;
+        const normalizedTags = Array.isArray(annotation.tags)
+            ? annotation.tags
+                .map(tag => typeof tag === 'string' ? tag : tag.id || tag.name)
+                .filter((tagId): tagId is string => typeof tagId === 'string' && tagId.trim().length > 0)
+            : [];
+
+        return {
+            ...annotation,
+            filePath,
+            range: new vscode.Range(
+                new vscode.Position(start.line, start.character),
+                new vscode.Position(end.line, end.character)
+            ),
+            timestamp: this.parseTimestamp(annotation.timestamp),
+            tags: normalizedTags,
+            priority: this.normalizePriority(annotation.priority),
+        };
+    }
+
+    private parseAnnotationStorage(raw: unknown): ParsedAnnotationsPayload {
+        if (this.isAnnotationStorageFile(raw)) {
+            return {
+                workspaceAnnotations: raw.workspaceAnnotations,
+                needsSave: raw.schemaVersion !== STORAGE_SCHEMA_VERSION,
+            };
+        }
+
+        if (this.isLegacyAnnotationStorage(raw)) {
+            return {
+                workspaceAnnotations: raw.workspaceAnnotations,
+                needsSave: true,
+            };
+        }
+
+        throw new Error('Invalid annotation storage schema');
+    }
+
+    private parseCustomTagsStorage(raw: unknown): ParsedCustomTagsPayload {
+        if (this.isTagStorageFile(raw)) {
+            return {
+                customTags: raw.customTags,
+                needsSave: raw.schemaVersion !== STORAGE_SCHEMA_VERSION,
+            };
+        }
+
+        if (Array.isArray(raw)) {
+            return {
+                customTags: raw,
+                needsSave: true,
+            };
+        }
+
+        throw new Error('Invalid custom tag storage schema');
+    }
+
+    private isAnnotationStorageFile(raw: unknown): raw is AnnotationStorageFile {
+        if (!raw || typeof raw !== 'object') {
+            return false;
+        }
+
+        const candidate = raw as Partial<AnnotationStorageFile>;
+        return typeof candidate.schemaVersion === 'number'
+            && !!candidate.workspaceAnnotations
+            && typeof candidate.workspaceAnnotations === 'object';
+    }
+
+    private isLegacyAnnotationStorage(raw: unknown): raw is { workspaceAnnotations: Record<string, StoredAnnotation[]> } {
+        if (!raw || typeof raw !== 'object') {
+            return false;
+        }
+
+        const candidate = raw as { workspaceAnnotations?: unknown };
+        return !!candidate.workspaceAnnotations && typeof candidate.workspaceAnnotations === 'object';
+    }
+
+    private isTagStorageFile(raw: unknown): raw is TagStorageFile {
+        if (!raw || typeof raw !== 'object') {
+            return false;
+        }
+
+        const candidate = raw as Partial<TagStorageFile>;
+        return typeof candidate.schemaVersion === 'number' && Array.isArray(candidate.customTags);
+    }
+
+    private parseTimestamp(rawTimestamp: string): Date {
+        const timestamp = new Date(rawTimestamp);
+        return Number.isNaN(timestamp.getTime()) ? new Date(0) : timestamp;
+    }
+
+    private normalizePriority(priority: unknown): TagPriority | undefined {
+        if (priority === 'low' || priority === 'medium' || priority === 'high' || priority === 'critical') {
+            return priority;
+        }
+
+        return undefined;
+    }
+
+    private async writeJsonAtomically(filePath: string, payload: unknown): Promise<void> {
+        const directory = path.dirname(filePath);
+        const fileName = path.basename(filePath);
+        const tempPath = path.join(directory, `${fileName}.tmp`);
+        const backupPath = path.join(directory, `${fileName}.bak`);
+        const contents = `${JSON.stringify(payload, null, 2)}\n`;
+
+        await fs.promises.writeFile(tempPath, contents, 'utf-8');
+
+        const hasExistingFile = fs.existsSync(filePath);
+        if (hasExistingFile) {
+            if (fs.existsSync(backupPath)) {
+                await fs.promises.unlink(backupPath);
+            }
+
+            await fs.promises.rename(filePath, backupPath);
+        }
+
+        try {
+            await fs.promises.rename(tempPath, filePath);
+            if (fs.existsSync(backupPath)) {
+                await fs.promises.unlink(backupPath);
+            }
+        } catch (error) {
+            if (fs.existsSync(tempPath)) {
+                await fs.promises.unlink(tempPath);
+            }
+
+            if (fs.existsSync(backupPath) && !fs.existsSync(filePath)) {
+                await fs.promises.rename(backupPath, filePath);
+            }
+
+            throw error;
+        }
+    }
+
+    private async recoverCorruptFile(filePath: string, label: string): Promise<void> {
+        if (!filePath || !fs.existsSync(filePath)) {
+            return;
+        }
+
+        const parsedPath = path.parse(filePath);
+        const timestamp = new Date().toISOString().replace(/[.:]/g, '-');
+        const recoveredPath = path.join(parsedPath.dir, `${parsedPath.name}.corrupt-${timestamp}${parsedPath.ext}`);
+        await fs.promises.rename(filePath, recoveredPath);
+
+        void vscode.window.showWarningMessage(
+            `Annotative recovered an unreadable ${label} file and moved it to ${path.basename(recoveredPath)}.`
+        );
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,8 +33,12 @@ export interface AnnotationTag {
     isPreset: boolean; // Always false for user-created tags
 }
 
-// Backward compatibility: accept both string and AnnotationTag
-export type Tag = string | AnnotationTag;
+export interface AnnotationTagOption {
+    id: string;
+    label: string;
+    color?: string;
+    priority?: TagPriority;
+}
 
 export interface Annotation {
     id: string;
@@ -45,7 +49,7 @@ export interface Annotation {
     author: string;
     timestamp: Date;
     resolved: boolean;        // Resolution status - open (false) or resolved (true)
-    tags?: Tag[];
+    tags?: string[];
     priority?: TagPriority;
     color?: string;           // Hex color code - user's visual preference only
     aiConversations?: AIConversation[];
@@ -57,7 +61,37 @@ export interface AnnotationDecoration {
 }
 
 export interface AnnotationStorage {
+    schemaVersion: number;
     workspaceAnnotations: { [filePath: string]: Annotation[] };
+}
+
+export interface StoredPosition {
+    line: number;
+    character: number;
+}
+
+export interface StoredRange {
+    start: StoredPosition;
+    end: StoredPosition;
+}
+
+export type LegacyStoredTag = string | AnnotationTag;
+export type Tag = string | AnnotationTag;
+
+export interface StoredAnnotation extends Omit<Annotation, 'range' | 'timestamp' | 'tags'> {
+    range: StoredRange;
+    timestamp: string;
+    tags?: LegacyStoredTag[];
+}
+
+export interface AnnotationStorageFile {
+    schemaVersion: number;
+    workspaceAnnotations: { [filePath: string]: StoredAnnotation[] };
+}
+
+export interface TagStorageFile {
+    schemaVersion: number;
+    customTags: AnnotationTag[];
 }
 
 // Tag management

--- a/src/ui/annotationProvider.ts
+++ b/src/ui/annotationProvider.ts
@@ -13,11 +13,10 @@ import {
     groupByFile,
     groupByTag,
     groupByStatus,
-    groupByFolder,
-    groupByPriority
+    groupByFolder
 } from './grouping';
 
-export type GroupBy = 'file' | 'tag' | 'status' | 'folder' | 'priority';
+export type GroupBy = 'file' | 'tag' | 'status' | 'folder';
 
 export class AnnotationProvider implements vscode.TreeDataProvider<TreeItem> {
     private _onDidChangeTreeData: vscode.EventEmitter<TreeItem | undefined | null | void> = new vscode.EventEmitter<TreeItem | undefined | null | void>();
@@ -126,11 +125,9 @@ export class AnnotationProvider implements vscode.TreeDataProvider<TreeItem> {
             if (this.groupBy === 'file') {
                 return Promise.resolve(groupByFile(filteredAnnotations) as TreeItem[]);
             } else if (this.groupBy === 'tag') {
-                return Promise.resolve(groupByTag(filteredAnnotations) as TreeItem[]);
+                return Promise.resolve(groupByTag(filteredAnnotations, (tagId) => this.annotationManager.resolveTagLabel(tagId)) as TreeItem[]);
             } else if (this.groupBy === 'folder') {
                 return Promise.resolve(groupByFolder(filteredAnnotations) as TreeItem[]);
-            } else if (this.groupBy === 'priority') {
-                return Promise.resolve(groupByPriority(filteredAnnotations) as TreeItem[]);
             } else {
                 return Promise.resolve(groupByStatus(filteredAnnotations) as TreeItem[]);
             }
@@ -142,7 +139,8 @@ export class AnnotationProvider implements vscode.TreeDataProvider<TreeItem> {
                 new AnnotationItem(
                     annotation,
                     vscode.TreeItemCollapsibleState.None,
-                    this.isAnnotationSelected(annotation.id)
+                    this.isAnnotationSelected(annotation.id),
+                    this.annotationManager.resolveTagLabels(annotation.tags)
                 )
             );
             return Promise.resolve(annotationItems as TreeItem[]);
@@ -188,7 +186,8 @@ export class AnnotationProvider implements vscode.TreeDataProvider<TreeItem> {
                 new AnnotationItem(
                     annotation,
                     vscode.TreeItemCollapsibleState.None,
-                    this.isAnnotationSelected(annotation.id)
+                    this.isAnnotationSelected(annotation.id),
+                    this.annotationManager.resolveTagLabels(annotation.tags)
                 )
             );
             return Promise.resolve(annotationItems as TreeItem[]);

--- a/src/ui/filtering/filterAnnotations.ts
+++ b/src/ui/filtering/filterAnnotations.ts
@@ -26,10 +26,7 @@ export function filterAnnotations(
             if (!annotation.tags) {
                 return false;
             }
-            const hasTag = annotation.tags.some(tag => {
-                const tagId = typeof tag === 'string' ? tag : tag.id;
-                return tagId === filterTag;
-            });
+            const hasTag = annotation.tags.some(tagId => tagId === filterTag);
             if (!hasTag) {
                 return false;
             }
@@ -41,10 +38,7 @@ export function filterAnnotations(
             const commentMatch = annotation.comment.toLowerCase().includes(searchLower);
             const textMatch = annotation.text.toLowerCase().includes(searchLower);
             const authorMatch = annotation.author.toLowerCase().includes(searchLower);
-            const tagMatch = annotation.tags?.some(tag => {
-                const tagName = typeof tag === 'string' ? tag : tag.name;
-                return tagName.toLowerCase().includes(searchLower);
-            });
+            const tagMatch = annotation.tags?.some(tagId => tagId.toLowerCase().includes(searchLower));
 
             if (!commentMatch && !textMatch && !authorMatch && !tagMatch) {
                 return false;

--- a/src/ui/grouping/groupByTag.ts
+++ b/src/ui/grouping/groupByTag.ts
@@ -5,7 +5,10 @@ import { GroupCategoryItem } from '../treeItems';
 /**
  * Groups annotations by tag
  */
-export function groupByTag(annotations: Annotation[]): GroupCategoryItem[] {
+export function groupByTag(
+    annotations: Annotation[],
+    resolveTagLabel: (tagId: string) => string = (tagId) => tagId
+): GroupCategoryItem[] {
     const tagGroups = new Map<string, Annotation[]>();
     const untaggedAnnotations: Annotation[] = [];
 
@@ -13,8 +16,7 @@ export function groupByTag(annotations: Annotation[]): GroupCategoryItem[] {
         if (!annotation.tags || annotation.tags.length === 0) {
             untaggedAnnotations.push(annotation);
         } else {
-            annotation.tags.forEach(tag => {
-                const tagId = typeof tag === 'string' ? tag : tag.id;
+            annotation.tags.forEach(tagId => {
                 if (!tagGroups.has(tagId)) {
                     tagGroups.set(tagId, []);
                 }
@@ -28,9 +30,9 @@ export function groupByTag(annotations: Annotation[]): GroupCategoryItem[] {
     // Add tagged groups
     Array.from(tagGroups.entries())
         .sort((a, b) => a[0].localeCompare(b[0]))
-        .forEach(([tag, anns]) => {
+        .forEach(([tagId, anns]) => {
             tagItems.push(new GroupCategoryItem(
-                `${tag} (${anns.length})`,
+                `${resolveTagLabel(tagId)} (${anns.length})`,
                 anns,
                 vscode.TreeItemCollapsibleState.Expanded
             ));

--- a/src/ui/sidebarWebview.ts
+++ b/src/ui/sidebarWebview.ts
@@ -164,7 +164,7 @@ export class SidebarWebview implements vscode.WebviewViewProvider {
             annotations,
         });
 
-        const tags = this.annotationManager.getAllTags();
+        const tags = this.annotationManager.getTagOptions();
         this.postMessage({
             command: 'tagsUpdated',
             tags,
@@ -327,9 +327,7 @@ export class SidebarWebview implements vscode.WebviewViewProvider {
             });
 
             if (newComment !== undefined && newComment.trim().length > 0) {
-                const currentTags = annotation.tags?.map((t) =>
-                    typeof t === 'string' ? t : t.id
-                ) || [];
+                const currentTags = annotation.tags || [];
 
                 await this.annotationManager.editAnnotation(
                     annotation.id,
@@ -375,9 +373,7 @@ export class SidebarWebview implements vscode.WebviewViewProvider {
             const annotation = allAnnotations.find((a) => a.id === id);
 
             if (annotation) {
-                const currentTags = annotation.tags?.map((t) =>
-                    typeof t === 'string' ? t : t.id
-                ) || [];
+                const currentTags = annotation.tags || [];
 
                 if (!currentTags.includes(tag)) {
                     const updatedTags = [...currentTags, tag];
@@ -404,9 +400,7 @@ export class SidebarWebview implements vscode.WebviewViewProvider {
             const annotation = allAnnotations.find((a) => a.id === id);
 
             if (annotation) {
-                const currentTags = annotation.tags?.map((t) =>
-                    typeof t === 'string' ? t : t.id
-                ) || [];
+                const currentTags = annotation.tags || [];
 
                 const updatedTags = currentTags.filter(t => t !== tag);
                 await this.annotationManager.editAnnotation(

--- a/src/ui/treeItems/annotationItem.ts
+++ b/src/ui/treeItems/annotationItem.ts
@@ -8,14 +8,15 @@ export class AnnotationItem extends vscode.TreeItem {
     constructor(
         public readonly annotation: Annotation,
         public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-        public readonly isSelected: boolean = false
+        public readonly isSelected: boolean = false,
+        tagLabels: string[] = annotation.tags || []
     ) {
         const statusIcon = annotation.resolved ? '✓' : '○';
         const selectedIcon = isSelected ? '☑ ' : '☐ ';
         const preview = annotation.comment.length > 45
             ? annotation.comment.substring(0, 42) + '...'
             : annotation.comment;
-        const tagsLabel = annotation.tags && annotation.tags.length > 0 ? ` [${annotation.tags.join(', ')}]` : '';
+        const tagsLabel = tagLabels.length > 0 ? ` [${tagLabels.join(', ')}]` : '';
 
         super(`${selectedIcon}${statusIcon} Line ${annotation.range.start.line + 1}: ${preview}${tagsLabel}`, collapsibleState);
 

--- a/src/ui/webview/htmlBuilder.ts
+++ b/src/ui/webview/htmlBuilder.ts
@@ -56,7 +56,6 @@ export function generateWebviewHtml(options: HtmlBuilderOptions): string {
                         <option value="tag">Tag</option>
                         <option value="status">Status</option>
                         <option value="folder">Folder</option>
-                        <option value="priority">Priority</option>
                     </select>
                 </div>
             </section>

--- a/src/ui/webview/types.ts
+++ b/src/ui/webview/types.ts
@@ -3,7 +3,7 @@
  * Defines all message interfaces for communication between webview and extension
  */
 
-import { Annotation } from '../../types';
+import { Annotation, AnnotationTagOption } from '../../types';
 
 /**
  * Messages sent FROM the webview TO the extension
@@ -46,7 +46,7 @@ export type ExtensionToWebviewCommand =
 export interface ExtensionMessage {
   command: ExtensionToWebviewCommand;
   annotations?: Annotation[];
-  tags?: string[];
+  tags?: AnnotationTagOption[];
   annotation?: Annotation;
   filters?: FilterState;
   [key: string]: unknown;
@@ -59,7 +59,7 @@ export interface FilterState {
   status: 'all' | 'resolved' | 'unresolved';
   tag: string;
   search: string;
-  groupBy: 'file' | 'tag' | 'status' | 'folder' | 'priority';
+  groupBy: 'file' | 'tag' | 'status' | 'folder';
 }
 
 /**

--- a/src/ui/webview/utils.ts
+++ b/src/ui/webview/utils.ts
@@ -38,10 +38,7 @@ export function filterAnnotations(
 
     // Filter by tag
     if (filters.tag && filters.tag !== 'all') {
-      const hasTag = ann.tags?.some((t) => {
-        const tagId = typeof t === 'string' ? t : t.id;
-        return tagId === filters.tag;
-      });
+      const hasTag = ann.tags?.some((tagId) => tagId === filters.tag);
       if (!hasTag) {
         return false;
       }
@@ -79,15 +76,12 @@ export function groupAnnotations(
       key = parts.length > 1 ? parts[parts.length - 2] : 'Root';
     } else if (groupBy === 'tag') {
       if (ann.tags && ann.tags.length > 0) {
-        const tagId = typeof ann.tags[0] === 'string' ? ann.tags[0] : ann.tags[0].id;
-        key = tagId;
+        key = ann.tags[0];
       } else {
         key = 'Untagged';
       }
     } else if (groupBy === 'status') {
       key = ann.resolved ? 'Resolved' : 'Unresolved';
-    } else if (groupBy === 'priority') {
-      key = ann.priority || 'Default';
     }
 
     if (!groups[key]) {
@@ -118,8 +112,7 @@ export function extractTags(annotations: Annotation[]): string[] {
   const tags = new Set<string>();
   annotations.forEach((ann) => {
     if (ann.tags && Array.isArray(ann.tags)) {
-      ann.tags.forEach((t) => {
-        const tagId = typeof t === 'string' ? t : t.id;
+      ann.tags.forEach((tagId) => {
         tags.add(tagId);
       });
     }


### PR DESCRIPTION
## Summary

This branch tightens Annotative's sidebar/state flow and hardens project-local persistence for annotations and tags. It adds schema-aware storage with safer writes and recovery, normalizes annotation tags to canonical tag IDs, and removes misleading priority and migration UI paths that were not backed by real persisted behavior.

## Why

- Project-local storage was doing direct whole-file JSON overwrites without schema/version handling or a recovery path for unreadable files.
- Annotation tags were persisted inconsistently as names, IDs, and objects, which made filtering, grouping, and export behavior less reliable.
- The UI exposed priority grouping and a "migrate existing" storage option even though those paths were not grounded in a consistent persisted model.
- The sidebar/webview flow needed to keep using a single source of truth for filter and tag state instead of mixing display labels with stored values.

## What changed

- Added versioned storage envelopes for annotations and custom tags, plus safer temp-file/rename persistence and corrupt-file recovery for project-local storage.
- Normalized stored annotation tags to string IDs only, and added load-time migration for legacy tag names and tag objects before re-saving in canonical form.
- Updated sidebar, tag commands, tree rendering, and Markdown export to resolve tag labels at display time from the tag registry instead of treating stored names as canonical data.
- Removed the active priority grouping option from the shipped sidebar/filter UI because annotation priority was not a maintained canonical field.
- Removed the no-op `migrateExisting` initialization choice so project storage initialization reflects what the extension actually does.
- Preserved the branch's sidebar/webview state consolidation work so filter and tag state stay synchronized in the live webview path.

## Validation

- `npm run compile`
- `npm run lint`
- `node scripts/check-extension-compliance.js --verbose`
- `npx vsce package`
- `npm run test` currently still fails due to the pre-existing Windows VS Code test harness path-resolution issue: `Cannot find module 'c:\Projects\Personal'`

## Notes

- This branch intentionally focuses on correctness and resilience; it does not add new storage or tagging features.
- No new regression tests or documentation updates were added in this bundle.
- Existing compliance warnings for console statements in `media/sidebar-webview.js` remain and were not addressed here.
- Follow-up work should cover automated tests for storage migration/recovery and a fix for the existing Windows test harness failure.