### PR TITLE
test: repair VS Code test harness and add regression coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -426,7 +426,7 @@
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "eslint src",
-    "test": "vscode-test",
+    "test": "node ./scripts/run-vscode-tests.mjs",
     "dev": "npm run watch",
     "ci": "git add . && npm run changeset:enhanced && git push origin main --no-verify",
     "clean": "rimraf dist out",

--- a/scripts/run-vscode-tests.mjs
+++ b/scripts/run-vscode-tests.mjs
@@ -1,0 +1,102 @@
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDirectory, '..');
+const compiledSuiteRoot = path.join(repoRoot, 'out', 'test', 'suite');
+const workspaceFolder = path.join(repoRoot, 'src', 'test', 'fixtures', 'workspace');
+const extensionTestsPath = path.join(repoRoot, 'node_modules', '@vscode', 'test-cli', 'out', 'runner.cjs');
+const vscodeTestRoot = path.join(repoRoot, '.vscode-test');
+
+const testFiles = await collectTestFiles(compiledSuiteRoot);
+if (testFiles.length === 0) {
+    throw new Error(`No compiled tests found under ${compiledSuiteRoot}`);
+}
+
+await fs.mkdir(vscodeTestRoot, { recursive: true });
+
+const runDirectory = await fs.mkdtemp(path.join(vscodeTestRoot, 'run-'));
+const userDataDirectory = path.join(runDirectory, 'user-data');
+const extensionsDirectory = path.join(runDirectory, 'extensions');
+
+await fs.mkdir(userDataDirectory, { recursive: true });
+await fs.mkdir(extensionsDirectory, { recursive: true });
+
+const vscodeExecutablePath = await downloadAndUnzipVSCode('stable');
+const env = {
+    ...process.env,
+    VSCODE_TEST_OPTIONS: JSON.stringify({
+        mochaOpts: {
+            ui: 'tdd',
+            timeout: 20000,
+        },
+        colorDefault: !!process.stdout.isTTY,
+        preload: [],
+        files: testFiles,
+    }),
+};
+
+delete env.ELECTRON_RUN_AS_NODE;
+
+const args = [
+    workspaceFolder,
+    '--no-sandbox',
+    '--disable-gpu-sandbox',
+    '--disable-updates',
+    '--skip-welcome',
+    '--skip-release-notes',
+    '--disable-workspace-trust',
+    `--user-data-dir=${userDataDirectory}`,
+    `--extensions-dir=${extensionsDirectory}`,
+    `--extensionTestsPath=${extensionTestsPath}`,
+    `--extensionDevelopmentPath=${repoRoot}`,
+];
+
+try {
+    const exitCode = await runTests(vscodeExecutablePath, args, env);
+    process.exitCode = exitCode;
+} finally {
+    await fs.rm(runDirectory, { recursive: true, force: true });
+}
+
+async function collectTestFiles(directory) {
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+    const files = [];
+
+    for (const entry of entries) {
+        const entryPath = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            files.push(...await collectTestFiles(entryPath));
+            continue;
+        }
+
+        if (entry.isFile() && entry.name.endsWith('.test.js')) {
+            files.push(entryPath);
+        }
+    }
+
+    return files.sort((left, right) => left.localeCompare(right));
+}
+
+function runTests(executablePath, args, env) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(executablePath, args, {
+            env,
+            stdio: 'inherit',
+        });
+
+        child.once('error', reject);
+        child.once('exit', (code, signal) => {
+            if (signal) {
+                reject(new Error(`VS Code tests terminated with signal ${signal}`));
+                return;
+            }
+
+            resolve(code ?? 1);
+        });
+    });
+}

--- a/src/managers/annotationCRUD.ts
+++ b/src/managers/annotationCRUD.ts
@@ -205,20 +205,16 @@ export class AnnotationCRUD {
             const fileAnnotations = this.annotations.get(filePath);
             if (fileAnnotations) {
                 const before = fileAnnotations.length;
-                this.annotations.set(
-                    filePath,
-                    fileAnnotations.filter(ann => !ann.resolved)
-                );
-                deletedCount = before - (fileAnnotations.length);
+                const remainingAnnotations = fileAnnotations.filter(ann => !ann.resolved);
+                this.annotations.set(filePath, remainingAnnotations);
+                deletedCount = before - remainingAnnotations.length;
             }
         } else {
             this.annotations.forEach((fileAnnotations, path) => {
                 const before = fileAnnotations.length;
-                this.annotations.set(
-                    path,
-                    fileAnnotations.filter(ann => !ann.resolved)
-                );
-                deletedCount += before - (fileAnnotations.length);
+                const remainingAnnotations = fileAnnotations.filter(ann => !ann.resolved);
+                this.annotations.set(path, remainingAnnotations);
+                deletedCount += before - remainingAnnotations.length;
             });
         }
 

--- a/src/managers/annotationManager.ts
+++ b/src/managers/annotationManager.ts
@@ -28,6 +28,7 @@ export class AnnotationManager {
     private exporter: AnnotationExporter;
     private onDidChangeAnnotationsEmitter = new vscode.EventEmitter<void>();
     public readonly onDidChangeAnnotations = this.onDidChangeAnnotationsEmitter.event;
+    public readonly ready: Promise<void>;
 
     constructor(private context: vscode.ExtensionContext) {
         this.tagManager = new TagManager();
@@ -36,7 +37,7 @@ export class AnnotationManager {
         this.crud = new AnnotationCRUD(this.annotations, this.decorations, this.storage);
         this.exporter = new AnnotationExporter(this.annotations, (tagIds) => this.resolveTagLabels(tagIds));
 
-        void this.initialize();
+        this.ready = this.initialize();
     }
 
     private async initialize(): Promise<void> {

--- a/src/test/fixtures/workspace/sample.ts
+++ b/src/test/fixtures/workspace/sample.ts
@@ -1,0 +1,1 @@
+export const sampleValue = 42;

--- a/src/test/suite/crud.test.ts
+++ b/src/test/suite/crud.test.ts
@@ -1,0 +1,107 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { AnnotationCRUD } from '../../managers';
+import { Annotation } from '../../types';
+import { createAnnotation } from './testUtils';
+
+suite('AnnotationCRUD', () => {
+    test('supports add, edit, resolve, unresolve, and remove flows', async () => {
+        const annotations = new Map<string, Annotation[]>();
+        const decorationUpdates: Annotation[][] = [];
+        let saveCount = 0;
+        const filePath = 'c:\\workspace\\crud-flow.ts';
+        const editor = {
+            document: {
+                uri: vscode.Uri.file(filePath),
+                getText: () => 'const answer = 42;',
+            },
+        } as unknown as vscode.TextEditor;
+        const crud = new AnnotationCRUD(
+            annotations,
+            {
+                updateDecorations: (_editor: vscode.TextEditor, fileAnnotations: Annotation[]) => {
+                    decorationUpdates.push([...fileAnnotations]);
+                },
+            } as unknown as never,
+            {
+                saveAnnotations: async () => {
+                    saveCount += 1;
+                },
+            } as unknown as never
+        );
+        const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 12));
+
+        const created = await crud.addAnnotation(editor, range, 'Add regression coverage.', ['bug'], '#42A5F5');
+
+        assert.strictEqual(annotations.get(filePath)?.length, 1);
+        assert.strictEqual(created.comment, 'Add regression coverage.');
+        assert.deepStrictEqual(created.tags, ['bug']);
+        assert.strictEqual(created.color, '#42A5F5');
+        assert.ok(created.author.length > 0);
+        assert.strictEqual(saveCount, 1);
+        assert.strictEqual(decorationUpdates.length, 1);
+
+        await crud.editAnnotation(created.id, filePath, 'Updated comment.', ['security'], '#FF5252');
+        assert.strictEqual(annotations.get(filePath)?.[0].comment, 'Updated comment.');
+        assert.deepStrictEqual(annotations.get(filePath)?.[0].tags, ['security']);
+        assert.strictEqual(annotations.get(filePath)?.[0].color, '#FF5252');
+
+        await crud.toggleResolvedStatus(created.id, filePath);
+        assert.strictEqual(annotations.get(filePath)?.[0].resolved, true);
+
+        await crud.toggleResolvedStatus(created.id, filePath);
+        assert.strictEqual(annotations.get(filePath)?.[0].resolved, false);
+
+        await crud.removeAnnotation(created.id, filePath);
+        assert.strictEqual(annotations.get(filePath)?.length, 0);
+        assert.strictEqual(saveCount, 5);
+    });
+
+    test('resolves and deletes resolved annotations at file and workspace scope', async () => {
+        const fileOne = 'c:\\workspace\\file-one.ts';
+        const fileTwo = 'c:\\workspace\\file-two.ts';
+        const annotations = new Map<string, Annotation[]>([
+            [
+                fileOne,
+                [
+                    createAnnotation({ filePath: fileOne, id: 'one-open', resolved: false }),
+                    createAnnotation({ filePath: fileOne, id: 'one-resolved', resolved: true }),
+                ],
+            ],
+            [
+                fileTwo,
+                [
+                    createAnnotation({ filePath: fileTwo, id: 'two-open', resolved: false }),
+                ],
+            ],
+        ]);
+        let saveCount = 0;
+        const crud = new AnnotationCRUD(
+            annotations,
+            { updateDecorations: () => undefined } as unknown as never,
+            {
+                saveAnnotations: async () => {
+                    saveCount += 1;
+                },
+            } as unknown as never
+        );
+
+        const deletedFromFile = await crud.deleteResolved(fileOne);
+        assert.strictEqual(deletedFromFile, 1);
+        assert.deepStrictEqual(
+            annotations.get(fileOne)?.map(annotation => annotation.id),
+            ['one-open']
+        );
+
+        const resolvedAcrossWorkspace = await crud.resolveAll();
+        assert.strictEqual(resolvedAcrossWorkspace, 2);
+        assert.ok(annotations.get(fileOne)?.every(annotation => annotation.resolved));
+        assert.ok(annotations.get(fileTwo)?.every(annotation => annotation.resolved));
+
+        const deletedAcrossWorkspace = await crud.deleteResolved();
+        assert.strictEqual(deletedAcrossWorkspace, 2);
+        assert.deepStrictEqual(annotations.get(fileOne), []);
+        assert.deepStrictEqual(annotations.get(fileTwo), []);
+        assert.strictEqual(saveCount, 3);
+    });
+});

--- a/src/test/suite/exporter.test.ts
+++ b/src/test/suite/exporter.test.ts
@@ -1,0 +1,102 @@
+import * as assert from 'assert';
+import { AnnotationExporter } from '../../managers';
+import { CopilotExporter } from '../../copilotExporter';
+import { Annotation } from '../../types';
+import { createAnnotation, ensureWorkspaceFile } from './testUtils';
+
+suite('Exporters', () => {
+    test('exports markdown grouped by file with resolved tag labels', async () => {
+        const filePath = await ensureWorkspaceFile('exports/example.ts', 'export const value = 42;\n');
+        const annotations = new Map<string, Annotation[]>([
+            [
+                filePath,
+                [
+                    createAnnotation({
+                        filePath,
+                        id: 'markdown-export',
+                        comment: 'Check the exported value.',
+                        tags: ['bug-tag', 'docs-tag'],
+                    }),
+                ],
+            ],
+        ]);
+        const exporter = new AnnotationExporter(annotations, (tagIds) =>
+            (tagIds || []).map(tagId => ({ 'bug-tag': 'Bug', 'docs-tag': 'Docs' }[tagId] || tagId))
+        );
+
+        const markdown = await exporter.exportToMarkdown();
+
+        assert.ok(markdown.includes('# Code Annotations - workspace'));
+        assert.ok(markdown.includes('## .test-artifacts/workspace-files/exports/example.ts'));
+        assert.ok(markdown.includes('### [Open] Annotation 1'));
+        assert.ok(markdown.includes('**Comment:**\nCheck the exported value.'));
+        assert.ok(markdown.includes('**Tags:** Bug, Docs'));
+    });
+
+    test('exports AI-specific formats and intent filters from current behavior', async () => {
+        const filePath = await ensureWorkspaceFile('exports/ai.ts', 'export function render() {}\n');
+        const annotations = [
+            createAnnotation({
+                filePath,
+                id: 'review-annotation',
+                comment: 'Review this bug fix.',
+                tags: ['bug'],
+                resolved: false,
+            }),
+            createAnnotation({
+                filePath,
+                id: 'resolved-annotation',
+                comment: 'Document this branch.',
+                tags: ['documentation'],
+                resolved: true,
+            }),
+            createAnnotation({
+                filePath,
+                id: 'performance-annotation',
+                comment: 'Optimize this hot path.',
+                tags: ['performance'],
+                resolved: false,
+            }),
+        ];
+
+        const reviewExport = CopilotExporter.exportByIntent(annotations, 'review');
+        const bugExport = CopilotExporter.exportByIntent(annotations, 'bugs');
+        const chatGptExport = CopilotExporter.exportForAI(annotations, {
+            format: 'chatgpt',
+            includeResolved: true,
+            contextLines: 5,
+            includeImports: false,
+            includeFunction: false,
+        });
+        const claudeExport = CopilotExporter.exportForAI(annotations, {
+            format: 'claude',
+            includeResolved: true,
+            contextLines: 5,
+            includeImports: false,
+            includeFunction: false,
+        });
+        const genericExport = CopilotExporter.exportForAI(annotations, {
+            format: 'generic',
+            includeResolved: true,
+            contextLines: 5,
+            includeImports: false,
+            includeFunction: false,
+        });
+
+        assert.ok(reviewExport.includes('Review this bug fix.'));
+        assert.ok(reviewExport.includes('Optimize this hot path.'));
+        assert.ok(!reviewExport.includes('Document this branch.'));
+
+        assert.ok(bugExport.includes('Review this bug fix.'));
+        assert.ok(!bugExport.includes('Optimize this hot path.'));
+
+        assert.ok(chatGptExport.includes('# Code Review Request'));
+        assert.ok(chatGptExport.includes('### Issue 1'));
+
+        assert.ok(claudeExport.includes('<code_review>'));
+        assert.ok(claudeExport.includes('<file path=".test-artifacts/workspace-files/exports/ai.ts">'));
+
+        assert.ok(genericExport.includes('# Code Review Annotations (3 items)'));
+        assert.ok(genericExport.includes('## Summary'));
+    });
+});

--- a/src/test/suite/manager.test.ts
+++ b/src/test/suite/manager.test.ts
@@ -1,0 +1,114 @@
+import * as assert from 'assert';
+import { AnnotationManager } from '../../managers';
+import { AnnotationStorageFile, TagStorageFile } from '../../types';
+import {
+    clearTestWorkspace,
+    createAnnotation,
+    createCustomTag,
+    createTestContext,
+    ensureWorkspaceFile,
+    getStoragePaths,
+    readJson,
+    toStoredAnnotation,
+    writeJson,
+} from './testUtils';
+
+suite('AnnotationManager', () => {
+    teardown(async () => {
+        await clearTestWorkspace();
+    });
+
+    test('migrates loaded tag names to ids and persists canonical tags', async () => {
+        await clearTestWorkspace();
+
+        const filePath = await ensureWorkspaceFile('manager-migration.ts', 'const answer = 42;\n');
+        const { annotationsPath, customTagsPath } = getStoragePaths();
+        const customTags = [
+            createCustomTag({
+                id: 'needs-review',
+                name: 'Needs Review',
+                metadata: { priority: 'high', color: '#42A5F5' },
+            }),
+        ];
+        const legacyAnnotation = createAnnotation({
+            filePath,
+            id: 'migration-target',
+            tags: ['Needs Review', 'needs-review', '   '],
+            comment: 'Normalize this tag set.',
+        });
+
+        await writeJson(customTagsPath, {
+            schemaVersion: 1,
+            customTags,
+        } satisfies TagStorageFile);
+        await writeJson(annotationsPath, {
+            schemaVersion: 1,
+            workspaceAnnotations: {
+                [filePath]: [toStoredAnnotation(legacyAnnotation)],
+            },
+        } satisfies AnnotationStorageFile);
+
+        const manager = new AnnotationManager(createTestContext());
+        await manager.ready;
+
+        const loadedAnnotation = manager.getAnnotationsForFile(filePath)[0];
+        assert.deepStrictEqual(loadedAnnotation.tags, ['needs-review']);
+        assert.strictEqual(manager.resolveTagLabel('needs-review'), 'Needs Review');
+        assert.strictEqual(manager.getAnnotationPriority(loadedAnnotation), 'high');
+
+        const persisted = await readJson<AnnotationStorageFile>(annotationsPath);
+        assert.deepStrictEqual(persisted.workspaceAnnotations[filePath][0].tags, ['needs-review']);
+
+        manager.dispose();
+    });
+
+    test('preserves annotation tag ids across tag rename and delete operations', async () => {
+        await clearTestWorkspace();
+
+        const filePath = await ensureWorkspaceFile('manager-tags.ts', 'const review = true;\n');
+        const { annotationsPath, customTagsPath } = getStoragePaths();
+        const customTags = [
+            createCustomTag({ id: 'bug-tag', name: 'Bug Tag' }),
+            createCustomTag({ id: 'critical-tag', name: 'Critical Tag', metadata: { priority: 'critical' } }),
+        ];
+        const storedAnnotation = createAnnotation({
+            filePath,
+            id: 'tagged-annotation',
+            tags: ['bug-tag', 'critical-tag'],
+            comment: 'Keep ids stable while labels change.',
+        });
+
+        await writeJson(customTagsPath, {
+            schemaVersion: 1,
+            customTags,
+        } satisfies TagStorageFile);
+        await writeJson(annotationsPath, {
+            schemaVersion: 1,
+            workspaceAnnotations: {
+                [filePath]: [toStoredAnnotation(storedAnnotation)],
+            },
+        } satisfies AnnotationStorageFile);
+
+        const manager = new AnnotationManager(createTestContext());
+        await manager.ready;
+
+        const annotation = manager.getAnnotationsForFile(filePath)[0];
+        assert.strictEqual(manager.getAnnotationPriority(annotation), 'critical');
+        assert.strictEqual(
+            manager.getAnnotationPriority(createAnnotation({ filePath, id: 'default-priority', tags: ['bug-tag'] })),
+            'medium'
+        );
+
+        const updated = await manager.updateCustomTag('bug-tag', 'Bugs');
+        assert.strictEqual(updated?.name, 'Bugs');
+        assert.deepStrictEqual(annotation.tags, ['bug-tag', 'critical-tag']);
+        assert.strictEqual(manager.resolveTagLabel('bug-tag'), 'Bugs');
+
+        const deleted = await manager.deleteCustomTag('bug-tag');
+        assert.strictEqual(deleted, true);
+        assert.deepStrictEqual(annotation.tags, ['bug-tag', 'critical-tag']);
+        assert.strictEqual(manager.resolveTagLabel('bug-tag'), 'bug-tag');
+
+        manager.dispose();
+    });
+});

--- a/src/test/suite/sidebarWebview.test.ts
+++ b/src/test/suite/sidebarWebview.test.ts
@@ -1,0 +1,155 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { AnnotationTagOption } from '../../types';
+import { SidebarWebview } from '../../ui/sidebarWebview';
+import { createAnnotation, getWorkspaceRoot } from './testUtils';
+
+class FakeWebview {
+    public html = '';
+    public options: vscode.WebviewOptions | undefined;
+    public readonly cspSource = 'vscode-webview://test';
+    public readonly postedMessages: Array<{ command: string; [key: string]: unknown }> = [];
+    private messageHandler: ((message: unknown) => Promise<void> | void) | undefined;
+
+    asWebviewUri(uri: vscode.Uri): vscode.Uri {
+        return uri;
+    }
+
+    onDidReceiveMessage(handler: (message: unknown) => Promise<void> | void): vscode.Disposable {
+        this.messageHandler = handler;
+        return new vscode.Disposable(() => {
+            this.messageHandler = undefined;
+        });
+    }
+
+    async postMessage(message: { command: string; [key: string]: unknown }): Promise<boolean> {
+        this.postedMessages.push(message);
+        return true;
+    }
+
+    async dispatch(message: { command: string; [key: string]: unknown }): Promise<void> {
+        await this.messageHandler?.(message);
+    }
+}
+
+class FakeWebviewView {
+    public visible = true;
+
+    constructor(public readonly webview: FakeWebview) {}
+
+    onDidChangeVisibility(_listener: () => void): vscode.Disposable {
+        return new vscode.Disposable(() => undefined);
+    }
+}
+
+suite('SidebarWebview', () => {
+    test('loads initial annotations, tags, and filter state into the webview', () => {
+        const filePath = `${getWorkspaceRoot()}\\sample.ts`;
+        const annotation = createAnnotation({ filePath, id: 'sidebar-initial' });
+        const tags: AnnotationTagOption[] = [{ id: 'bug-tag', label: 'Bug', priority: 'high' }];
+        const annotationManager = {
+            getAllAnnotations: () => [annotation],
+            getTagOptions: () => tags,
+        };
+        const sidebar = new SidebarWebview(vscode.Uri.file(getWorkspaceRoot()), annotationManager as never);
+        const webview = new FakeWebview();
+
+        sidebar.resolveWebviewView(
+            new FakeWebviewView(webview) as unknown as vscode.WebviewView,
+            {} as vscode.WebviewViewResolveContext,
+            {} as vscode.CancellationToken
+        );
+
+        assert.strictEqual(webview.postedMessages.length, 3);
+        assert.deepStrictEqual(webview.postedMessages.map(message => message.command), [
+            'updateAnnotations',
+            'tagsUpdated',
+            'filterStateUpdated',
+        ]);
+        assert.ok(webview.html.includes('sidebar-webview.js'));
+    });
+
+    test('routes critical sidebar messages to the annotation manager and tracks filters', async () => {
+        const filePath = `${getWorkspaceRoot()}\\sidebar-actions.ts`;
+        const annotation = createAnnotation({
+            filePath,
+            id: 'sidebar-actions',
+            tags: ['bug-tag'],
+            comment: 'Original sidebar comment.',
+        });
+        const calls = {
+            toggles: [] as Array<{ id: string; filePath: string }>,
+            removals: [] as Array<{ id: string; filePath: string }>,
+            edits: [] as Array<{ id: string; filePath: string; comment: string; tags: string[]; color?: string }>,
+            resolveAll: 0,
+            deleteResolved: 0,
+        };
+        const annotationManager = {
+            getAllAnnotations: () => [annotation],
+            getTagOptions: () => [{ id: 'bug-tag', label: 'Bug' }],
+            toggleResolvedStatus: async (id: string, targetFilePath: string) => {
+                calls.toggles.push({ id, filePath: targetFilePath });
+                annotation.resolved = !annotation.resolved;
+            },
+            removeAnnotation: async (id: string, targetFilePath: string) => {
+                calls.removals.push({ id, filePath: targetFilePath });
+            },
+            editAnnotation: async (
+                id: string,
+                targetFilePath: string,
+                comment: string,
+                tags: string[],
+                color?: string
+            ) => {
+                calls.edits.push({ id, filePath: targetFilePath, comment, tags, color });
+                annotation.comment = comment;
+                annotation.tags = [...tags];
+                annotation.color = color;
+            },
+            resolveAll: async () => {
+                calls.resolveAll += 1;
+                return 1;
+            },
+            deleteResolved: async () => {
+                calls.deleteResolved += 1;
+                return 1;
+            },
+        };
+        const sidebar = new SidebarWebview(vscode.Uri.file(getWorkspaceRoot()), annotationManager as never);
+        const webview = new FakeWebview();
+
+        sidebar.resolveWebviewView(
+            new FakeWebviewView(webview) as unknown as vscode.WebviewView,
+            {} as vscode.WebviewViewResolveContext,
+            {} as vscode.CancellationToken
+        );
+
+        await webview.dispatch({
+            command: 'filterStateChanged',
+            filters: { status: 'resolved', tag: 'bug-tag', search: 'sidebar' },
+        });
+        assert.deepStrictEqual(sidebar.getFilterState(), {
+            status: 'resolved',
+            tag: 'bug-tag',
+            search: 'sidebar',
+            groupBy: 'file',
+        });
+
+        await webview.dispatch({ command: 'toggleResolved', id: 'sidebar-actions' });
+        await webview.dispatch({ command: 'addTag', id: 'sidebar-actions', tag: 'docs-tag' });
+        await webview.dispatch({ command: 'removeTag', id: 'sidebar-actions', tag: 'bug-tag' });
+        await webview.dispatch({ command: 'manageTags', id: 'sidebar-actions', tags: ['docs-tag', 'security-tag'] });
+        await webview.dispatch({ command: 'resolveAll' });
+        await webview.dispatch({ command: 'deleteResolved' });
+        await webview.dispatch({ command: 'delete', id: 'sidebar-actions' });
+
+        assert.deepStrictEqual(calls.toggles, [{ id: 'sidebar-actions', filePath }]);
+        assert.deepStrictEqual(calls.removals, [{ id: 'sidebar-actions', filePath }]);
+        assert.strictEqual(calls.edits.length, 3);
+        assert.deepStrictEqual(calls.edits[0].tags, ['bug-tag', 'docs-tag']);
+        assert.deepStrictEqual(calls.edits[1].tags, ['docs-tag']);
+        assert.deepStrictEqual(calls.edits[2].tags, ['docs-tag', 'security-tag']);
+        assert.strictEqual(calls.resolveAll, 1);
+        assert.strictEqual(calls.deleteResolved, 1);
+    });
+});

--- a/src/test/suite/storage.test.ts
+++ b/src/test/suite/storage.test.ts
@@ -1,0 +1,130 @@
+import * as assert from 'assert';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { AnnotationStorageManager } from '../../managers';
+import { AnnotationStorageFile, TagStorageFile } from '../../types';
+import {
+    clearTestWorkspace,
+    createAnnotation,
+    createCustomTag,
+    createTestContext,
+    ensureWorkspaceFile,
+    getStoragePaths,
+    writeJson,
+} from './testUtils';
+
+suite('AnnotationStorageManager', () => {
+    setup(async () => {
+        await clearTestWorkspace();
+    });
+
+    teardown(async () => {
+        await clearTestWorkspace();
+    });
+
+    test('round-trips annotations and custom tags', async () => {
+        const annotations = new Map();
+        const storage = new AnnotationStorageManager(annotations, createTestContext());
+        const filePath = await ensureWorkspaceFile('storage-roundtrip.ts', 'const answer = 42;\n');
+        const annotation = createAnnotation({
+            filePath,
+            id: 'storage-roundtrip',
+            comment: 'Persist this annotation.',
+            tags: ['needs-review'],
+            priority: 'high',
+            color: '#42A5F5',
+        });
+        const customTags = [
+            createCustomTag({
+                id: 'needs-review',
+                name: 'Needs Review',
+                metadata: { priority: 'high', color: '#42A5F5' },
+            }),
+        ];
+
+        annotations.set(filePath, [annotation]);
+
+        await storage.saveAnnotations();
+        await storage.saveCustomTags(customTags);
+
+        annotations.clear();
+
+        const annotationLoad = await storage.loadAnnotations();
+        const loadedTags = await storage.loadCustomTags();
+
+        assert.strictEqual(annotationLoad.needsSave, false);
+        assert.strictEqual(loadedTags.needsSave, false);
+        assert.deepStrictEqual(loadedTags.tags, customTags);
+
+        const loadedAnnotation = annotations.get(filePath)?.[0];
+        assert.ok(loadedAnnotation, 'Expected the saved annotation to load back from storage.');
+        assert.strictEqual(loadedAnnotation.id, annotation.id);
+        assert.strictEqual(loadedAnnotation.comment, annotation.comment);
+        assert.strictEqual(loadedAnnotation.timestamp.toISOString(), annotation.timestamp.toISOString());
+        assert.deepStrictEqual(loadedAnnotation.tags, ['needs-review']);
+        assert.strictEqual(loadedAnnotation.priority, 'high');
+        assert.strictEqual(loadedAnnotation.color, '#42A5F5');
+    });
+
+    test('quarantines a corrupted annotation storage file and resets in-memory state', async () => {
+        const annotations = new Map();
+        const storage = new AnnotationStorageManager(annotations, createTestContext());
+        const { storageDir, annotationsPath } = getStoragePaths();
+
+        await storage.ensureProjectStorage();
+        await fs.mkdir(storageDir, { recursive: true });
+        await fs.writeFile(annotationsPath, '{ invalid json', 'utf-8');
+
+        const result = await storage.loadAnnotations();
+        const storageEntries = await fs.readdir(storageDir);
+
+        assert.strictEqual(result.needsSave, false);
+        assert.strictEqual(annotations.size, 0);
+        assert.ok(
+            storageEntries.some(name => /^annotations\.corrupt-.*\.json$/.test(name)),
+            'Expected a quarantined copy of the corrupt annotations file.'
+        );
+        assert.ok(!storageEntries.includes('annotations.json'));
+    });
+
+    test('loads legacy schemas and signals that they should be rewritten', async () => {
+        const annotations = new Map();
+        const storage = new AnnotationStorageManager(annotations, createTestContext());
+        const filePath = await ensureWorkspaceFile('legacy-schema.ts', 'const legacy = true;\n');
+        const legacyAnnotation = createAnnotation({
+            filePath,
+            id: 'legacy-annotation',
+            comment: 'Legacy payload.',
+            tags: ['legacy-tag'],
+        });
+        const { annotationsPath, customTagsPath } = getStoragePaths();
+
+        await storage.ensureProjectStorage();
+
+        await writeJson(annotationsPath, {
+            workspaceAnnotations: {
+                [filePath]: [
+                    {
+                        ...legacyAnnotation,
+                        range: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 0, character: 5 },
+                        },
+                        timestamp: legacyAnnotation.timestamp.toISOString(),
+                    },
+                ],
+            },
+        });
+        await writeJson(customTagsPath, [createCustomTag({ id: 'legacy-tag', name: 'Legacy Tag' })]);
+
+        const annotationLoad = await storage.loadAnnotations();
+        const tagLoad = await storage.loadCustomTags();
+
+        assert.strictEqual(annotationLoad.needsSave, true);
+        assert.strictEqual(tagLoad.needsSave, true);
+
+        const loadedAnnotation = annotations.get(filePath)?.[0];
+        assert.ok(loadedAnnotation, 'Expected the legacy annotation payload to load.');
+        assert.deepStrictEqual(loadedAnnotation.tags, ['legacy-tag']);
+    });
+});

--- a/src/test/suite/testUtils.ts
+++ b/src/test/suite/testUtils.ts
@@ -1,0 +1,97 @@
+import * as assert from 'assert';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { Annotation, AnnotationTag, StoredAnnotation } from '../../types';
+
+export function getWorkspaceRoot(): string {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    assert.ok(workspaceFolder, 'Expected the VS Code test workspace to be open.');
+    return workspaceFolder.uri.fsPath;
+}
+
+export function createTestContext(): vscode.ExtensionContext {
+    const workspaceRoot = getWorkspaceRoot();
+
+    return {
+        subscriptions: [],
+        extensionUri: vscode.Uri.file(workspaceRoot),
+        asAbsolutePath: (relativePath: string) => path.join(workspaceRoot, relativePath),
+    } as unknown as vscode.ExtensionContext;
+}
+
+export async function clearTestWorkspace(): Promise<void> {
+    const workspaceRoot = getWorkspaceRoot();
+    await fs.rm(path.join(workspaceRoot, '.annotative'), { recursive: true, force: true });
+    await fs.rm(path.join(workspaceRoot, '.test-artifacts'), { recursive: true, force: true });
+}
+
+export async function ensureWorkspaceFile(relativePath: string, contents: string): Promise<string> {
+    const filePath = path.join(getWorkspaceRoot(), '.test-artifacts', 'workspace-files', relativePath);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, contents, 'utf-8');
+    return filePath;
+}
+
+export async function writeJson(filePath: string, payload: unknown): Promise<void> {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf-8');
+}
+
+export async function readJson<T>(filePath: string): Promise<T> {
+    return JSON.parse(await fs.readFile(filePath, 'utf-8')) as T;
+}
+
+export function getStoragePaths(): { storageDir: string; annotationsPath: string; customTagsPath: string } {
+    const storageDir = path.join(getWorkspaceRoot(), '.annotative');
+    return {
+        storageDir,
+        annotationsPath: path.join(storageDir, 'annotations.json'),
+        customTagsPath: path.join(storageDir, 'customTags.json'),
+    };
+}
+
+export function createAnnotation(overrides: Partial<Annotation> & { filePath: string }): Annotation {
+    return {
+        id: overrides.id ?? 'annotation-1',
+        filePath: overrides.filePath,
+        range: overrides.range ?? new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 12)),
+        text: overrides.text ?? 'const answer = 42;',
+        comment: overrides.comment ?? 'Review this code path.',
+        author: overrides.author ?? 'Test User',
+        timestamp: overrides.timestamp ?? new Date('2026-03-24T12:00:00.000Z'),
+        resolved: overrides.resolved ?? false,
+        tags: overrides.tags ?? [],
+        priority: overrides.priority,
+        color: overrides.color ?? '#ffc107',
+        aiConversations: overrides.aiConversations,
+    };
+}
+
+export function toStoredAnnotation(annotation: Annotation): StoredAnnotation {
+    return {
+        ...annotation,
+        range: {
+            start: {
+                line: annotation.range.start.line,
+                character: annotation.range.start.character,
+            },
+            end: {
+                line: annotation.range.end.line,
+                character: annotation.range.end.character,
+            },
+        },
+        timestamp: annotation.timestamp.toISOString(),
+        tags: annotation.tags ? [...annotation.tags] : undefined,
+    };
+}
+
+export function createCustomTag(overrides: Partial<AnnotationTag> & { id: string; name: string }): AnnotationTag {
+    return {
+        id: overrides.id,
+        name: overrides.name,
+        category: overrides.category ?? 'issue',
+        metadata: overrides.metadata,
+        isPreset: overrides.isPreset ?? false,
+    };
+}


### PR DESCRIPTION
## Summary

This branch repairs the VS Code extension test harness so `npm test` works reliably from this Windows workspace path and replaces the placeholder test coverage with a focused regression suite for core existing behaviors. It also fixes an existing `deleteResolved` counting bug that the new tests exposed.

## Why

- The previous `vscode-test` path failed on Windows when the repo lived under a path with spaces, which left the branch without a reliable test gate.
- The repo only had placeholder coverage, so storage, CRUD, export, tag, and sidebar behaviors could regress without protection.

## What changed

- Replaced the `npm test` entrypoint with a custom VS Code test launcher that safely runs the compiled suite through the existing in-host Mocha runner and avoids the Windows path/module-resolution failure.
- Added a deterministic regression suite covering storage round-trip and corrupt-file recovery, annotation CRUD flows, tag migration and priority behavior, exporter output, and sidebar webview message routing.
- Added a small `AnnotationManager.ready` seam so manager-level tests can await async initialization without redesigning production code.
- Corrected `AnnotationCRUD.deleteResolved()` so deleted counts are computed from the filtered results instead of the pre-filter array length.
- Added a minimal fixture workspace sample and test utilities, while keeping runtime-created test files under `.test-artifacts` so test runs do not dirty the repo with generated files.

## Validation

- `npm test`
- `npm run compile && npm run lint`
- Verified the VS Code test run passes with 11 passing tests covering storage, CRUD, manager/tag, exporter, and sidebar webview behavior.

## Notes

- Out of scope for this branch: new product features, broader extension activation smoke coverage, and full end-to-end UI command testing.
- The custom launcher is a targeted workaround for the current Windows path handling issue in the upstream VS Code test launch path; if upstream behavior changes, this runner may be worth revisiting.
- The new suite intentionally exercises corrupt storage recovery, so a JSON parse error is still logged during that test before the recovery assertions pass.
- Follow-up opportunity: add a small activation-level smoke test and targeted Copilot chat integration coverage.