### PR TITLE
feat: improve annotation anchoring and conservative reattachment

### DIFF
--- a/src/commands/filters.ts
+++ b/src/commands/filters.ts
@@ -110,11 +110,13 @@ export function registerFilterCommands(
         async (annotation: Annotation) => {
             try {
                 const document = await vscode.workspace.openTextDocument(vscode.Uri.file(annotation.filePath));
+                await annotationManager.rebaseAnnotationsForDocument(document);
                 const editor = await vscode.window.showTextDocument(document);
+                const resolvedAnnotation = annotationManager.getAnnotation(annotation.id, annotation.filePath) || annotation;
 
                 // Reveal and select the annotated range
-                editor.revealRange(annotation.range, vscode.TextEditorRevealType.InCenter);
-                editor.selection = new vscode.Selection(annotation.range.start, annotation.range.end);
+                editor.revealRange(resolvedAnnotation.range, vscode.TextEditorRevealType.InCenter);
+                editor.selection = new vscode.Selection(resolvedAnnotation.range.start, resolvedAnnotation.range.end);
             } catch (error) {
                 vscode.window.showErrorMessage(`Cannot open: ${annotation.filePath}`);
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,6 +82,34 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    context.subscriptions.push(
+        vscode.workspace.onDidOpenTextDocument(document => {
+            void annotationManager.rebaseAnnotationsForDocument(document).then(changed => {
+                if (changed) {
+                    const activeEditor = vscode.window.activeTextEditor;
+                    if (activeEditor && activeEditor.document.uri.toString() === document.uri.toString()) {
+                        annotationManager.updateDecorations(activeEditor);
+                    }
+                }
+            });
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeTextDocument(event => {
+            void annotationManager.rebaseAnnotationsForDocument(event.document).then(changed => {
+                if (changed) {
+                    const visibleEditor = vscode.window.visibleTextEditors.find(
+                        editor => editor.document.uri.toString() === event.document.uri.toString()
+                    );
+                    if (visibleEditor) {
+                        annotationManager.updateDecorations(visibleEditor);
+                    }
+                }
+            });
+        })
+    );
+
     if (vscode.window.activeTextEditor) {
         annotationManager.updateDecorations(vscode.window.activeTextEditor);
     }

--- a/src/managers/annotationAnchors.ts
+++ b/src/managers/annotationAnchors.ts
@@ -1,0 +1,474 @@
+import * as vscode from 'vscode';
+import { Annotation, AnnotationAnchor, StoredRange } from '../types';
+
+const ANCHOR_CONTEXT_CHARS = 48;
+const MIN_CONTEXT_CHARS = 6;
+
+interface TextIndex {
+    lineOffsets: number[];
+    normalizedText: string;
+    normalizedOffsets: number[];
+}
+
+interface CandidateMatch {
+    startOffset: number;
+    endOffset: number;
+    score: number;
+}
+
+export interface ReattachmentResult {
+    range: vscode.Range;
+    text: string;
+    anchor?: AnnotationAnchor;
+    changed: boolean;
+    reattached: boolean;
+}
+
+export function captureAnnotationAnchor(documentText: string, range: vscode.Range): AnnotationAnchor | undefined {
+    const index = buildTextIndex(documentText);
+    const offsets = clampRangeOffsets(range, documentText, index.lineOffsets);
+    if (offsets.startOffset >= offsets.endOffset) {
+        return undefined;
+    }
+
+    const selectedText = documentText.slice(offsets.startOffset, offsets.endOffset);
+    const prefixContext = documentText.slice(Math.max(0, offsets.startOffset - ANCHOR_CONTEXT_CHARS), offsets.startOffset);
+    const suffixContext = documentText.slice(offsets.endOffset, Math.min(documentText.length, offsets.endOffset + ANCHOR_CONTEXT_CHARS));
+
+    return {
+        selectedText,
+        prefixContext,
+        suffixContext,
+        selectedTextHash: hashString(selectedText),
+        normalizedTextHash: hashString(normalizeSnippet(selectedText)),
+        contextHash: hashString(`${normalizeSnippet(prefixContext)}|${normalizeSnippet(suffixContext)}`),
+    };
+}
+
+export function reattachAnnotation(annotation: Annotation, documentText: string): ReattachmentResult {
+    const index = buildTextIndex(documentText);
+    const fallbackOffsets = clampStoredRange(annotation.range, documentText, index.lineOffsets);
+    const fallbackRange = createRangeFromOffsets(fallbackOffsets.startOffset, fallbackOffsets.endOffset, index.lineOffsets);
+    const fallbackText = documentText.slice(fallbackOffsets.startOffset, fallbackOffsets.endOffset);
+    const fallbackAnchor = captureAnnotationAnchor(documentText, fallbackRange);
+
+    if (!annotation.anchor?.selectedText) {
+        return {
+            range: fallbackRange,
+            text: fallbackText,
+            anchor: fallbackAnchor,
+            changed: !annotation.range.isEqual(fallbackRange) || annotation.text !== fallbackText || !anchorsEqual(annotation.anchor, fallbackAnchor),
+            reattached: false,
+        };
+    }
+
+    const anchor = annotation.anchor;
+    const exactMatch = findExactAnchorMatch(anchor, documentText, index, fallbackOffsets.startOffset);
+    if (exactMatch) {
+        return buildResolvedResult(annotation, documentText, index.lineOffsets, exactMatch.startOffset, exactMatch.endOffset, true);
+    }
+
+    const contextualMatch = findContextualAnchorMatch(anchor, documentText, index, fallbackOffsets.startOffset);
+    if (contextualMatch) {
+        return buildResolvedResult(annotation, documentText, index.lineOffsets, contextualMatch.startOffset, contextualMatch.endOffset, true);
+    }
+
+    return {
+        range: fallbackRange,
+        text: fallbackText,
+        anchor: fallbackAnchor,
+        changed: !annotation.range.isEqual(fallbackRange) || annotation.text !== fallbackText || !anchorsEqual(annotation.anchor, fallbackAnchor),
+        reattached: false,
+    };
+}
+
+function buildResolvedResult(
+    annotation: Annotation,
+    documentText: string,
+    lineOffsets: number[],
+    startOffset: number,
+    endOffset: number,
+    reattached: boolean,
+): ReattachmentResult {
+    const range = createRangeFromOffsets(startOffset, endOffset, lineOffsets);
+    const text = documentText.slice(startOffset, endOffset);
+    const anchor = captureAnnotationAnchor(documentText, range);
+
+    return {
+        range,
+        text,
+        anchor,
+        changed: !annotation.range.isEqual(range) || annotation.text !== text || !anchorsEqual(annotation.anchor, anchor),
+        reattached,
+    };
+}
+
+function findExactAnchorMatch(
+    anchor: AnnotationAnchor,
+    documentText: string,
+    index: TextIndex,
+    originalStartOffset: number,
+): CandidateMatch | undefined {
+    const normalizedNeedle = normalizeSnippet(anchor.selectedText);
+    if (!normalizedNeedle) {
+        return undefined;
+    }
+
+    const prefix = normalizeSnippet(anchor.prefixContext);
+    const suffix = normalizeSnippet(anchor.suffixContext);
+    const candidates: CandidateMatch[] = [];
+    let searchIndex = 0;
+
+    while (searchIndex <= index.normalizedText.length) {
+        const matchIndex = index.normalizedText.indexOf(normalizedNeedle, searchIndex);
+        if (matchIndex === -1) {
+            break;
+        }
+
+        const startOffset = index.normalizedOffsets[matchIndex] ?? 0;
+        const lastCharOffset = index.normalizedOffsets[matchIndex + normalizedNeedle.length - 1] ?? startOffset;
+        const endOffset = Math.min(documentText.length, lastCharOffset + 1);
+        let score = 55;
+
+        if (prefix) {
+            const prefixText = index.normalizedText.slice(Math.max(0, matchIndex - prefix.length), matchIndex);
+            if (prefixText === prefix) {
+                score += 20;
+            }
+        }
+
+        if (suffix) {
+            const suffixText = index.normalizedText.slice(matchIndex + normalizedNeedle.length, matchIndex + normalizedNeedle.length + suffix.length);
+            if (suffixText === suffix) {
+                score += 20;
+            }
+        }
+
+        if (hashString(normalizeSnippet(documentText.slice(startOffset, endOffset))) === anchor.normalizedTextHash) {
+            score += 10;
+        }
+
+        score += proximityScore(startOffset, originalStartOffset, Math.max(1, normalizedNeedle.length));
+        candidates.push({ startOffset, endOffset, score });
+        searchIndex = matchIndex + 1;
+    }
+
+    return pickBestCandidate(candidates, 65);
+}
+
+function findContextualAnchorMatch(
+    anchor: AnnotationAnchor,
+    documentText: string,
+    index: TextIndex,
+    originalStartOffset: number,
+): CandidateMatch | undefined {
+    const prefix = normalizeSnippet(anchor.prefixContext);
+    const suffix = normalizeSnippet(anchor.suffixContext);
+    const normalizedSelection = normalizeSnippet(anchor.selectedText);
+
+    if (!prefix || !suffix || Math.max(prefix.length, suffix.length) < MIN_CONTEXT_CHARS || !normalizedSelection) {
+        return undefined;
+    }
+
+    const maxGap = Math.max(normalizedSelection.length * 3, normalizedSelection.length + 80, 120);
+    const candidates: CandidateMatch[] = [];
+    let prefixIndex = 0;
+
+    while (prefixIndex <= index.normalizedText.length) {
+        const prefixMatchIndex = index.normalizedText.indexOf(prefix, prefixIndex);
+        if (prefixMatchIndex === -1) {
+            break;
+        }
+
+        let suffixIndex = prefixMatchIndex + prefix.length;
+        while (suffixIndex <= index.normalizedText.length) {
+            const suffixMatchIndex = index.normalizedText.indexOf(suffix, suffixIndex);
+            if (suffixMatchIndex === -1) {
+                break;
+            }
+
+            const normalizedGap = suffixMatchIndex - (prefixMatchIndex + prefix.length);
+            if (normalizedGap <= 0) {
+                suffixIndex = suffixMatchIndex + 1;
+                continue;
+            }
+
+            if (normalizedGap > maxGap) {
+                break;
+            }
+
+            const prefixEndOffset = (index.normalizedOffsets[prefixMatchIndex + prefix.length - 1] ?? 0) + 1;
+            const suffixStartOffset = index.normalizedOffsets[suffixMatchIndex] ?? prefixEndOffset;
+            if (suffixStartOffset <= prefixEndOffset) {
+                suffixIndex = suffixMatchIndex + 1;
+                continue;
+            }
+
+            const trimmedOffsets = trimCandidateWhitespace(anchor.selectedText, documentText, prefixEndOffset, suffixStartOffset);
+            if (trimmedOffsets.endOffset <= trimmedOffsets.startOffset) {
+                suffixIndex = suffixMatchIndex + 1;
+                continue;
+            }
+
+            const candidateText = documentText.slice(trimmedOffsets.startOffset, trimmedOffsets.endOffset);
+            const similarity = diceCoefficient(normalizedSelection, normalizeSnippet(candidateText));
+            if (similarity < 0.35) {
+                suffixIndex = suffixMatchIndex + 1;
+                continue;
+            }
+
+            let score = 75;
+            score += Math.round(similarity * 20);
+            score += proximityScore(trimmedOffsets.startOffset, originalStartOffset, Math.max(1, normalizedSelection.length));
+            candidates.push({ startOffset: trimmedOffsets.startOffset, endOffset: trimmedOffsets.endOffset, score });
+            suffixIndex = suffixMatchIndex + 1;
+        }
+
+        prefixIndex = prefixMatchIndex + 1;
+    }
+
+    return pickBestCandidate(candidates, 85);
+}
+
+function pickBestCandidate(candidates: CandidateMatch[], minimumScore: number): CandidateMatch | undefined {
+    if (candidates.length === 0) {
+        return undefined;
+    }
+
+    const ranked = [...candidates].sort((left, right) => right.score - left.score);
+    const best = ranked[0];
+    const secondBest = ranked[1];
+
+    if (best.score < minimumScore) {
+        return undefined;
+    }
+
+    if (secondBest && best.score - secondBest.score < 15) {
+        return undefined;
+    }
+
+    return best;
+}
+
+function proximityScore(candidateStart: number, originalStart: number, anchorLength: number): number {
+    const distance = Math.abs(candidateStart - originalStart);
+    const unit = Math.max(16, anchorLength * 2);
+    return Math.max(0, 12 - Math.floor(distance / unit));
+}
+
+function diceCoefficient(left: string, right: string): number {
+    if (!left || !right) {
+        return 0;
+    }
+
+    if (left === right) {
+        return 1;
+    }
+
+    const leftBigrams = buildBigrams(left);
+    const rightBigrams = buildBigrams(right);
+    const remaining = new Map<string, number>();
+
+    rightBigrams.forEach(bigram => {
+        remaining.set(bigram, (remaining.get(bigram) ?? 0) + 1);
+    });
+
+    let intersection = 0;
+    leftBigrams.forEach(bigram => {
+        const count = remaining.get(bigram) ?? 0;
+        if (count > 0) {
+            remaining.set(bigram, count - 1);
+            intersection += 1;
+        }
+    });
+
+    return (2 * intersection) / (leftBigrams.length + rightBigrams.length);
+}
+
+function buildBigrams(value: string): string[] {
+    if (value.length < 2) {
+        return [value];
+    }
+
+    const bigrams: string[] = [];
+    for (let index = 0; index < value.length - 1; index += 1) {
+        bigrams.push(value.slice(index, index + 2));
+    }
+    return bigrams;
+}
+
+function buildTextIndex(documentText: string): TextIndex {
+    return {
+        lineOffsets: buildLineOffsets(documentText),
+        ...buildNormalizedText(documentText),
+    };
+}
+
+function buildLineOffsets(documentText: string): number[] {
+    const offsets = [0];
+    for (let index = 0; index < documentText.length; index += 1) {
+        if (documentText[index] === '\n') {
+            offsets.push(index + 1);
+        }
+    }
+    return offsets;
+}
+
+function buildNormalizedText(documentText: string): { normalizedText: string; normalizedOffsets: number[] } {
+    let normalizedText = '';
+    const normalizedOffsets: number[] = [];
+    let pendingWhitespaceOffset: number | undefined;
+
+    for (let index = 0; index < documentText.length; index += 1) {
+        const character = documentText[index];
+        if (/\s/.test(character)) {
+            pendingWhitespaceOffset ??= index;
+            continue;
+        }
+
+        const previousCharacter = normalizedText.length > 0 ? normalizedText[normalizedText.length - 1] : undefined;
+        if (
+            pendingWhitespaceOffset !== undefined
+            && previousCharacter
+            && !isNormalizedPunctuation(previousCharacter)
+            && !isNormalizedPunctuation(character)
+        ) {
+            normalizedText += ' ';
+            normalizedOffsets.push(pendingWhitespaceOffset);
+        }
+
+        normalizedText += character;
+        normalizedOffsets.push(index);
+        pendingWhitespaceOffset = undefined;
+    }
+
+    return { normalizedText, normalizedOffsets };
+}
+
+function clampStoredRange(range: vscode.Range, documentText: string, lineOffsets: number[]): { startOffset: number; endOffset: number } {
+    return clampRangeOffsets(range, documentText, lineOffsets);
+}
+
+function clampRangeOffsets(
+    range: vscode.Range | StoredRange,
+    documentText: string,
+    lineOffsets: number[],
+): { startOffset: number; endOffset: number } {
+    const startOffset = clampOffset(positionToOffset(range.start.line, range.start.character, documentText, lineOffsets), documentText.length);
+    const endOffset = clampOffset(positionToOffset(range.end.line, range.end.character, documentText, lineOffsets), documentText.length);
+
+    if (endOffset < startOffset) {
+        return { startOffset, endOffset: startOffset };
+    }
+
+    return { startOffset, endOffset };
+}
+
+function positionToOffset(line: number, character: number, documentText: string, lineOffsets: number[]): number {
+    if (line < 0) {
+        return 0;
+    }
+
+    if (line >= lineOffsets.length) {
+        return documentText.length;
+    }
+
+    const lineStart = lineOffsets[line];
+    const nextLineStart = line + 1 < lineOffsets.length ? lineOffsets[line + 1] : documentText.length;
+    return Math.min(lineStart + Math.max(0, character), nextLineStart);
+}
+
+function clampOffset(offset: number, documentLength: number): number {
+    return Math.max(0, Math.min(offset, documentLength));
+}
+
+function createRangeFromOffsets(startOffset: number, endOffset: number, lineOffsets: number[]): vscode.Range {
+    return new vscode.Range(offsetToPosition(startOffset, lineOffsets), offsetToPosition(endOffset, lineOffsets));
+}
+
+function offsetToPosition(offset: number, lineOffsets: number[]): vscode.Position {
+    let low = 0;
+    let high = lineOffsets.length - 1;
+
+    while (low <= high) {
+        const mid = Math.floor((low + high) / 2);
+        const lineStart = lineOffsets[mid];
+        const nextLineStart = mid + 1 < lineOffsets.length ? lineOffsets[mid + 1] : Number.MAX_SAFE_INTEGER;
+
+        if (offset < lineStart) {
+            high = mid - 1;
+            continue;
+        }
+
+        if (offset >= nextLineStart) {
+            low = mid + 1;
+            continue;
+        }
+
+        return new vscode.Position(mid, offset - lineStart);
+    }
+
+    const lastLine = Math.max(0, lineOffsets.length - 1);
+    return new vscode.Position(lastLine, Math.max(0, offset - lineOffsets[lastLine]));
+}
+
+function normalizeSnippet(value: string): string {
+    return value
+        .replace(/\s+/g, ' ')
+        .replace(/\s*([()[\]{}.,;:+\-*/%<>=!?&|])\s*/g, '$1')
+        .trim();
+}
+
+function isNormalizedPunctuation(value: string): boolean {
+    return /[()[\]{}.,;:+\-*/%<>=!?&|]/.test(value);
+}
+
+function trimCandidateWhitespace(
+    selectedText: string,
+    documentText: string,
+    startOffset: number,
+    endOffset: number,
+): { startOffset: number; endOffset: number } {
+    let nextStartOffset = startOffset;
+    let nextEndOffset = endOffset;
+
+    if (!/^\s/.test(selectedText)) {
+        while (nextStartOffset < nextEndOffset && /\s/.test(documentText[nextStartOffset])) {
+            nextStartOffset += 1;
+        }
+    }
+
+    if (!/\s$/.test(selectedText)) {
+        while (nextEndOffset > nextStartOffset && /\s/.test(documentText[nextEndOffset - 1])) {
+            nextEndOffset -= 1;
+        }
+    }
+
+    return { startOffset: nextStartOffset, endOffset: nextEndOffset };
+}
+
+function hashString(value: string): string {
+    let hash = 2166136261;
+    for (let index = 0; index < value.length; index += 1) {
+        hash ^= value.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+    }
+    return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function anchorsEqual(left?: AnnotationAnchor, right?: AnnotationAnchor): boolean {
+    if (!left && !right) {
+        return true;
+    }
+
+    if (!left || !right) {
+        return false;
+    }
+
+    return left.selectedText === right.selectedText
+        && left.prefixContext === right.prefixContext
+        && left.suffixContext === right.suffixContext
+        && left.selectedTextHash === right.selectedTextHash
+        && left.normalizedTextHash === right.normalizedTextHash
+        && left.contextHash === right.contextHash;
+}

--- a/src/managers/annotationCRUD.ts
+++ b/src/managers/annotationCRUD.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { Annotation } from '../types';
+import { captureAnnotationAnchor } from './annotationAnchors';
 import { AnnotationDecorations } from './annotationDecorations';
 import { AnnotationStorageManager } from './annotationStorage';
 
@@ -27,6 +28,7 @@ export class AnnotationCRUD {
         color?: string
     ): Promise<Annotation> {
         const filePath = editor.document.uri.fsPath;
+        const documentText = editor.document.getText();
         const selectedText = editor.document.getText(range);
 
         const annotation: Annotation = {
@@ -39,7 +41,8 @@ export class AnnotationCRUD {
             timestamp: new Date(),
             resolved: false,
             tags: tags || [],
-            color: color || '#ffc107'
+            color: color || '#ffc107',
+            anchor: captureAnnotationAnchor(documentText, range),
         };
 
         if (!this.annotations.has(filePath)) {
@@ -113,10 +116,16 @@ export class AnnotationCRUD {
                 if (color) {
                     annotation.color = color;
                 }
+
+                const activeEditor = vscode.window.activeTextEditor;
+                if (activeEditor && activeEditor.document.uri.fsPath === filePath) {
+                    annotation.text = activeEditor.document.getText(annotation.range);
+                    annotation.anchor = captureAnnotationAnchor(activeEditor.document.getText(), annotation.range);
+                }
+
                 await this.storage.saveAnnotations();
 
                 // Update decorations for the active editor if it matches
-                const activeEditor = vscode.window.activeTextEditor;
                 if (activeEditor && activeEditor.document.uri.fsPath === filePath) {
                     this.decorations.updateDecorations(activeEditor, fileAnnotations);
                 }

--- a/src/managers/annotationManager.ts
+++ b/src/managers/annotationManager.ts
@@ -11,6 +11,7 @@ import {
     TagSuggestion,
 } from '../types';
 import { TagManager } from '../tags';
+import { reattachAnnotation } from './annotationAnchors';
 import { AnnotationCRUD } from './annotationCRUD';
 import { AnnotationDecorations } from './annotationDecorations';
 import { AnnotationExportService } from './annotationExportService';
@@ -27,6 +28,7 @@ export class AnnotationManager {
     private storage: AnnotationStorageManager;
     private exportService: AnnotationExportService;
     private onDidChangeAnnotationsEmitter = new vscode.EventEmitter<void>();
+    private persistenceScheduled = false;
     public readonly onDidChangeAnnotations = this.onDidChangeAnnotationsEmitter.event;
     public readonly ready: Promise<void>;
 
@@ -44,8 +46,9 @@ export class AnnotationManager {
         await this.loadCustomTags();
         const annotationLoad = await this.storage.loadAnnotations();
         const migratedAnnotations = this.normalizeLoadedAnnotations();
+        const rebasedAnnotations = await this.rebaseStoredAnnotations();
 
-        if (annotationLoad.needsSave || migratedAnnotations) {
+        if (annotationLoad.needsSave || migratedAnnotations || rebasedAnnotations) {
             await this.storage.saveAnnotations();
         }
     }
@@ -203,20 +206,45 @@ export class AnnotationManager {
     }
 
     getAnnotationsForFile(filePath: string): Annotation[] {
+        const openDocument = this.findOpenDocument(filePath);
+        if (openDocument && this.rebaseAnnotationsForText(filePath, openDocument.getText())) {
+            this.scheduleAnnotationPersistence();
+        }
+
         return this.exportService.getAnnotationsForFile(filePath);
     }
 
     getAllAnnotations(): Annotation[] {
+        this.refreshOpenDocuments();
         return this.exportService.getAllAnnotations();
     }
 
     getStatistics(): AnnotationStatistics {
+        this.refreshOpenDocuments();
         return this.exportService.getStatistics();
     }
 
     updateDecorations(editor: vscode.TextEditor): void {
+        if (this.rebaseAnnotationsForText(editor.document.uri.fsPath, editor.document.getText())) {
+            this.scheduleAnnotationPersistence();
+        }
+
         const fileAnnotations = this.exportService.getAnnotationsForFile(editor.document.uri.fsPath);
         this.decorations.updateDecorations(editor, fileAnnotations);
+    }
+
+    async rebaseAnnotationsForDocument(document: vscode.TextDocument): Promise<boolean> {
+        if (document.uri.scheme !== 'file') {
+            return false;
+        }
+
+        const changed = this.rebaseAnnotationsForText(document.uri.fsPath, document.getText());
+        if (changed) {
+            await this.storage.saveAnnotations();
+            this.notifyAnnotationsChanged();
+        }
+
+        return changed;
     }
 
     async exportAnnotations(): Promise<ExportData> {
@@ -315,10 +343,86 @@ export class AnnotationManager {
                 }
 
                 annotation.tags = nextTags;
+
+                if (annotation.anchor && annotation.anchor.selectedText !== annotation.text) {
+                    changed = true;
+                }
             });
         });
 
         return changed;
+    }
+
+    private async rebaseStoredAnnotations(): Promise<boolean> {
+        const filePaths = Array.from(this.annotations.keys());
+        let changed = false;
+
+        for (const filePath of filePaths) {
+            try {
+                const fileContents = await vscode.workspace.fs.readFile(vscode.Uri.file(filePath));
+                const documentText = Buffer.from(fileContents).toString('utf-8');
+                changed = this.rebaseAnnotationsForText(filePath, documentText) || changed;
+            } catch {
+                continue;
+            }
+        }
+
+        return changed;
+    }
+
+    private rebaseAnnotationsForText(filePath: string, documentText: string): boolean {
+        const fileAnnotations = this.annotations.get(filePath);
+        if (!fileAnnotations || fileAnnotations.length === 0) {
+            return false;
+        }
+
+        let changed = false;
+        fileAnnotations.forEach(annotation => {
+            const reattached = reattachAnnotation(annotation, documentText);
+            if (!reattached.changed) {
+                return;
+            }
+
+            annotation.range = reattached.range;
+            annotation.text = reattached.text;
+            annotation.anchor = reattached.anchor;
+            changed = true;
+        });
+
+        return changed;
+    }
+
+    private refreshOpenDocuments(): void {
+        let changed = false;
+
+        vscode.workspace.textDocuments.forEach(document => {
+            if (document.uri.scheme !== 'file') {
+                return;
+            }
+
+            changed = this.rebaseAnnotationsForText(document.uri.fsPath, document.getText()) || changed;
+        });
+
+        if (changed) {
+            this.scheduleAnnotationPersistence();
+        }
+    }
+
+    private findOpenDocument(filePath: string): vscode.TextDocument | undefined {
+        return vscode.workspace.textDocuments.find(document => document.uri.scheme === 'file' && document.uri.fsPath === filePath);
+    }
+
+    private scheduleAnnotationPersistence(): void {
+        if (this.persistenceScheduled) {
+            return;
+        }
+
+        this.persistenceScheduled = true;
+        void Promise.resolve().then(async () => {
+            this.persistenceScheduled = false;
+            await this.storage.saveAnnotations();
+            this.notifyAnnotationsChanged();
+        });
     }
 
     private notifyAnnotationsChanged(): void {

--- a/src/managers/annotationStorage.ts
+++ b/src/managers/annotationStorage.ts
@@ -5,6 +5,7 @@ import {
     Annotation,
     AnnotationStorageFile,
     AnnotationTag,
+    AnnotationAnchor,
     StoredAnnotation,
     TagPriority,
     TagStorageFile,
@@ -15,7 +16,7 @@ import {
     resolveWorkspaceFolderForAnnotations,
 } from '../utils/workspaceContext';
 
-const STORAGE_SCHEMA_VERSION = 1;
+const STORAGE_SCHEMA_VERSION = 2;
 
 export interface LoadAnnotationsResult {
     needsSave: boolean;
@@ -44,6 +45,7 @@ export class AnnotationStorageManager {
     private storageFilePath = '';
     private customTagsPath = '';
     private projectStorageDir: string | undefined;
+    private writeQueue: Promise<void> = Promise.resolve();
 
     constructor(
         private annotations: Map<string, Annotation[]>,
@@ -158,19 +160,21 @@ export class AnnotationStorageManager {
 
     async saveAnnotations(): Promise<void> {
         try {
-            await this.ensureProjectStorage();
+            await this.enqueueWrite(async () => {
+                await this.ensureProjectStorage();
 
-            const storage: AnnotationStorageFile = {
-                schemaVersion: STORAGE_SCHEMA_VERSION,
-                workspaceAnnotations: Object.fromEntries(
-                    Array.from(this.annotations.entries()).map(([filePath, annotations]) => [
-                        filePath,
-                        annotations.map(annotation => this.serializeAnnotation(annotation))
-                    ])
-                )
-            };
+                const storage: AnnotationStorageFile = {
+                    schemaVersion: STORAGE_SCHEMA_VERSION,
+                    workspaceAnnotations: Object.fromEntries(
+                        Array.from(this.annotations.entries()).map(([filePath, annotations]) => [
+                            filePath,
+                            annotations.map(annotation => this.serializeAnnotation(annotation))
+                        ])
+                    )
+                };
 
-            await this.writeJsonAtomically(this.storageFilePath, storage);
+                await this.writeJsonAtomically(this.storageFilePath, storage);
+            });
         } catch (error) {
             console.error('Failed to save annotations:', error);
             vscode.window.showErrorMessage('Failed to save annotations');
@@ -197,14 +201,16 @@ export class AnnotationStorageManager {
 
     async saveCustomTags(tags: AnnotationTag[]): Promise<void> {
         try {
-            await this.ensureProjectStorage();
+            await this.enqueueWrite(async () => {
+                await this.ensureProjectStorage();
 
-            const storage: TagStorageFile = {
-                schemaVersion: STORAGE_SCHEMA_VERSION,
-                customTags: tags,
-            };
+                const storage: TagStorageFile = {
+                    schemaVersion: STORAGE_SCHEMA_VERSION,
+                    customTags: tags,
+                };
 
-            await this.writeJsonAtomically(this.customTagsPath, storage);
+                await this.writeJsonAtomically(this.customTagsPath, storage);
+            });
         } catch (error) {
             console.error('Failed to save custom tags:', error);
             vscode.window.showErrorMessage('Failed to save custom tags');
@@ -226,6 +232,7 @@ export class AnnotationStorageManager {
             },
             timestamp: annotation.timestamp.toISOString(),
             tags: annotation.tags ? [...annotation.tags] : undefined,
+            anchor: this.serializeAnchor(annotation.anchor),
         };
     }
 
@@ -248,6 +255,49 @@ export class AnnotationStorageManager {
             timestamp: this.parseTimestamp(annotation.timestamp),
             tags: normalizedTags,
             priority: this.normalizePriority(annotation.priority),
+            anchor: this.deserializeAnchor(annotation.anchor),
+        };
+    }
+
+    private serializeAnchor(anchor: AnnotationAnchor | undefined): AnnotationAnchor | undefined {
+        if (!anchor) {
+            return undefined;
+        }
+
+        return {
+            selectedText: anchor.selectedText,
+            prefixContext: anchor.prefixContext,
+            suffixContext: anchor.suffixContext,
+            selectedTextHash: anchor.selectedTextHash,
+            normalizedTextHash: anchor.normalizedTextHash,
+            contextHash: anchor.contextHash,
+        };
+    }
+
+    private deserializeAnchor(rawAnchor: unknown): AnnotationAnchor | undefined {
+        if (!rawAnchor || typeof rawAnchor !== 'object') {
+            return undefined;
+        }
+
+        const candidate = rawAnchor as Partial<AnnotationAnchor>;
+        if (
+            typeof candidate.selectedText !== 'string'
+            || typeof candidate.prefixContext !== 'string'
+            || typeof candidate.suffixContext !== 'string'
+            || typeof candidate.selectedTextHash !== 'string'
+            || typeof candidate.normalizedTextHash !== 'string'
+            || typeof candidate.contextHash !== 'string'
+        ) {
+            return undefined;
+        }
+
+        return {
+            selectedText: candidate.selectedText,
+            prefixContext: candidate.prefixContext,
+            suffixContext: candidate.suffixContext,
+            selectedTextHash: candidate.selectedTextHash,
+            normalizedTextHash: candidate.normalizedTextHash,
+            contextHash: candidate.contextHash,
         };
     }
 
@@ -363,6 +413,12 @@ export class AnnotationStorageManager {
 
             throw error;
         }
+    }
+
+    private async enqueueWrite<T>(operation: () => Promise<T>): Promise<T> {
+        const nextWrite = this.writeQueue.then(operation, operation);
+        this.writeQueue = nextWrite.then(() => undefined, () => undefined);
+        return nextWrite;
     }
 
     private async recoverCorruptFile(filePath: string, label: string): Promise<void> {

--- a/src/test/suite/anchoring.test.ts
+++ b/src/test/suite/anchoring.test.ts
@@ -1,0 +1,224 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { AnnotationManager } from '../../managers';
+import { captureAnnotationAnchor } from '../../managers/annotationAnchors';
+import { AnnotationStorageFile } from '../../types';
+import {
+    clearTestWorkspace,
+    createAnnotation,
+    createTestContext,
+    ensureWorkspaceFile,
+    getStoragePaths,
+    readJson,
+    toStoredAnnotation,
+    writeJson,
+} from './testUtils';
+
+suite('Annotation anchoring', () => {
+    teardown(async () => {
+        await clearTestWorkspace();
+    });
+
+    test('migrates legacy annotations by capturing anchors without changing unchanged ranges', async () => {
+        await clearTestWorkspace();
+
+        const contents = 'const answer = 42;\n';
+        const filePath = await ensureWorkspaceFile('anchors-legacy.ts', contents);
+        const storedAnnotation = buildStoredAnnotation({
+            filePath,
+            originalContents: contents,
+            selectedText: 'answer',
+            includeAnchor: false,
+        });
+
+        await writeAnnotationsFile(filePath, [storedAnnotation], 1);
+
+        const manager = new AnnotationManager(createTestContext());
+        await manager.ready;
+
+        const loadedAnnotation = manager.getAnnotationsForFile(filePath)[0];
+        assert.ok(loadedAnnotation.anchor, 'Expected the legacy annotation to gain an anchor during migration.');
+        assert.strictEqual(loadedAnnotation.range.start.line, 0);
+        assert.strictEqual(loadedAnnotation.range.start.character, 6);
+        assert.strictEqual(loadedAnnotation.text, 'answer');
+
+        const persisted = await readJson<AnnotationStorageFile>(getStoragePaths().annotationsPath);
+        assert.strictEqual(persisted.schemaVersion, 2);
+        assert.ok(persisted.workspaceAnnotations[filePath][0].anchor);
+
+        manager.dispose();
+    });
+
+    test('rebases annotations when lines are inserted above the anchored range', async () => {
+        await clearTestWorkspace();
+
+        const originalContents = 'const alpha = 1;\nconst target = alpha + 1;\n';
+        const currentContents = 'const inserted = true;\nconst alpha = 1;\nconst target = alpha + 1;\n';
+        const filePath = await ensureWorkspaceFile('anchors-shift.ts', currentContents);
+        const storedAnnotation = buildStoredAnnotation({
+            filePath,
+            originalContents,
+            selectedText: 'target = alpha + 1',
+        });
+
+        await writeAnnotationsFile(filePath, [storedAnnotation], 2);
+
+        const manager = new AnnotationManager(createTestContext());
+        await manager.ready;
+
+        const loadedAnnotation = manager.getAnnotationsForFile(filePath)[0];
+        assert.strictEqual(loadedAnnotation.range.start.line, 2);
+        assert.strictEqual(loadedAnnotation.text, 'target = alpha + 1');
+
+        manager.dispose();
+    });
+
+    test('reattaches annotations across nearby formatting changes and line movement', async () => {
+        await clearTestWorkspace();
+
+        const originalContents = 'const total = sum(a, b);\n';
+        const currentContents = 'const before = 1;\nconst total = sum(\n    a,\n    b\n);\n';
+        const filePath = await ensureWorkspaceFile('anchors-format.ts', currentContents);
+        const storedAnnotation = buildStoredAnnotation({
+            filePath,
+            originalContents,
+            selectedText: 'sum(a, b)',
+        });
+
+        await writeAnnotationsFile(filePath, [storedAnnotation], 2);
+
+        const manager = new AnnotationManager(createTestContext());
+        await manager.ready;
+
+        const loadedAnnotation = manager.getAnnotationsForFile(filePath)[0];
+        assert.strictEqual(loadedAnnotation.range.start.line, 1);
+        assert.strictEqual(loadedAnnotation.range.end.line, 4);
+        assert.strictEqual(loadedAnnotation.text, 'sum(\n    a,\n    b\n)');
+
+        manager.dispose();
+    });
+
+    test('reattaches annotations when the selected text changes but surrounding context stays stable', async () => {
+        await clearTestWorkspace();
+
+        const originalContents = 'function build(user) {\n    return getValue(user.id);\n}\n';
+        const currentContents = 'function build(user) {\n    return buildValue(user.id, ctx);\n}\n';
+        const filePath = await ensureWorkspaceFile('anchors-partial.ts', currentContents);
+        const storedAnnotation = buildStoredAnnotation({
+            filePath,
+            originalContents,
+            selectedText: 'getValue(user.id)',
+        });
+
+        await writeAnnotationsFile(filePath, [storedAnnotation], 2);
+
+        const manager = new AnnotationManager(createTestContext());
+        await manager.ready;
+
+        const loadedAnnotation = manager.getAnnotationsForFile(filePath)[0];
+        assert.strictEqual(loadedAnnotation.range.start.line, 1);
+        assert.strictEqual(loadedAnnotation.text, 'buildValue(user.id, ctx)');
+        assert.strictEqual(loadedAnnotation.anchor?.selectedText, 'buildValue(user.id, ctx)');
+
+        manager.dispose();
+    });
+
+    test('falls back conservatively when multiple matches are equally plausible', async () => {
+        await clearTestWorkspace();
+
+        const originalContents = 'duplicate(),\nduplicate(),\n';
+        const currentContents = 'duplicate(),\nduplicate(),\nduplicate(),\n';
+        const filePath = await ensureWorkspaceFile('anchors-ambiguous.ts', currentContents);
+        const storedAnnotation = buildStoredAnnotation({
+            filePath,
+            originalContents,
+            selectedText: 'duplicate()',
+        });
+
+        await writeAnnotationsFile(filePath, [storedAnnotation], 2);
+
+        const manager = new AnnotationManager(createTestContext());
+        await manager.ready;
+
+        const loadedAnnotation = manager.getAnnotationsForFile(filePath)[0];
+        assert.strictEqual(loadedAnnotation.range.start.line, 0);
+        assert.strictEqual(loadedAnnotation.range.start.character, 0);
+        assert.strictEqual(loadedAnnotation.text, 'duplicate()');
+
+        manager.dispose();
+    });
+});
+
+function buildStoredAnnotation(options: {
+    filePath: string;
+    originalContents: string;
+    selectedText: string;
+    includeAnchor?: boolean;
+    occurrence?: number;
+}) {
+    const range = findRange(options.originalContents, options.selectedText, options.occurrence ?? 0);
+    const annotation = createAnnotation({
+        filePath: options.filePath,
+        id: `${pathSafeId(options.filePath)}-${options.selectedText.length}`,
+        range,
+        text: options.originalContents.slice(
+            offsetAt(options.originalContents, range.start),
+            offsetAt(options.originalContents, range.end)
+        ),
+    });
+
+    if (options.includeAnchor !== false) {
+        annotation.anchor = captureAnnotationAnchor(options.originalContents, range);
+    }
+
+    return toStoredAnnotation(annotation);
+}
+
+async function writeAnnotationsFile(filePath: string, storedAnnotations: ReturnType<typeof buildStoredAnnotation>[], schemaVersion: number) {
+    await writeJson(getStoragePaths().annotationsPath, {
+        schemaVersion,
+        workspaceAnnotations: {
+            [filePath]: storedAnnotations,
+        },
+    } satisfies AnnotationStorageFile);
+}
+
+function findRange(contents: string, selectedText: string, occurrence: number): vscode.Range {
+    let searchFrom = 0;
+    let offset = -1;
+
+    for (let index = 0; index <= occurrence; index += 1) {
+        offset = contents.indexOf(selectedText, searchFrom);
+        if (offset === -1) {
+            throw new Error(`Could not find '${selectedText}' in test contents.`);
+        }
+        searchFrom = offset + 1;
+    }
+
+    return new vscode.Range(
+        positionAt(contents, offset),
+        positionAt(contents, offset + selectedText.length)
+    );
+}
+
+function positionAt(contents: string, offset: number): vscode.Position {
+    const clampedOffset = Math.max(0, Math.min(offset, contents.length));
+    const lines = contents.slice(0, clampedOffset).split('\n');
+    return new vscode.Position(lines.length - 1, lines[lines.length - 1].length);
+}
+
+function offsetAt(contents: string, position: vscode.Position): number {
+    const lines = contents.split('\n');
+    let offset = 0;
+
+    for (let line = 0; line < position.line; line += 1) {
+        offset += lines[line]?.length ?? 0;
+        offset += 1;
+    }
+
+    return offset + position.character;
+}
+
+function pathSafeId(filePath: string): string {
+    return filePath.replace(/[^a-z0-9]+/gi, '-').toLowerCase();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,15 @@ export interface AnnotationTagOption {
     priority?: TagPriority;
 }
 
+export interface AnnotationAnchor {
+    selectedText: string;
+    prefixContext: string;
+    suffixContext: string;
+    selectedTextHash: string;
+    normalizedTextHash: string;
+    contextHash: string;
+}
+
 export interface Annotation {
     id: string;
     filePath: string;
@@ -53,6 +62,7 @@ export interface Annotation {
     priority?: TagPriority;
     color?: string;           // Hex color code - user's visual preference only
     aiConversations?: AIConversation[];
+    anchor?: AnnotationAnchor;
 }
 
 export interface AnnotationDecoration {

--- a/src/ui/sidebarWebview.ts
+++ b/src/ui/sidebarWebview.ts
@@ -261,13 +261,15 @@ export class SidebarWebview implements vscode.WebviewViewProvider {
         try {
             const uri = vscode.Uri.file(annotation.filePath);
             const doc = await vscode.workspace.openTextDocument(uri);
+            await this.annotationManager.rebaseAnnotationsForDocument(doc);
             const editor = await vscode.window.showTextDocument(doc);
 
+            const resolvedAnnotation = this.annotationManager.getAnnotation(annotation.id, annotation.filePath) || annotation;
             const range = new vscode.Range(
-                annotation.range.start.line,
-                annotation.range.start.character,
-                annotation.range.end.line,
-                annotation.range.end.character
+                resolvedAnnotation.range.start.line,
+                resolvedAnnotation.range.start.character,
+                resolvedAnnotation.range.end.line,
+                resolvedAnnotation.range.end.character
             );
 
             editor.selection = new vscode.Selection(range.start, range.end);


### PR DESCRIPTION
## Summary

This branch hardens existing annotation behavior so persisted annotations survive common source edits more reliably. It adds conservative anchor metadata, reattachment/rebasing logic, and regression coverage without introducing new user-facing features.

## Why

- Annotation identity was still heavily range-based, which made existing annotations fragile under line inserts, formatting changes, and partial code edits.
- The branch needed a safer way to recover annotation locations while remaining conservative when a confident match cannot be made.

## What changed

- Extended persisted annotations to store resilient anchor data alongside the existing range fallback, including selected text, nearby prefix/suffix context, and simple hashes for normalized matching.
- Added centralized reattachment/rebasing logic and wired it into annotation load, document open/change handling, decoration updates, and explicit navigation flows so existing annotations can recover before being rendered or opened.
- Updated annotation create/edit flows to capture fresh anchor metadata, serialized the new schema safely, serialized storage writes to avoid file-write races, and added targeted regression tests for unchanged files, edits above annotations, formatting/line movement, partial replacements, and ambiguous fallback cases.

## Validation

- `npm run lint`
- `node check-extension-compliance.js --verbose`
- `npm test`
- `npx vsce package`

## Notes

- Reattachment is intentionally conservative: if multiple candidates are similarly plausible or context is too weak, the code falls back to the stored range instead of guessing.
- This change is scoped to existing annotation resilience only; it does not add new UX, new controls, or new annotation features.
- The branch includes broader stacked-branch groundwork in its history, but this PR’s functional focus is annotation anchoring and reattachment.
- The compliance check still reports existing console-statement warnings in sidebar-webview.js; they do not block packaging and were left out of scope for this pass.