### PR TITLE
Performance fix for large text files.

### DIFF
--- a/src/managers/annotationAnchors.ts
+++ b/src/managers/annotationAnchors.ts
@@ -315,7 +315,7 @@ function buildLineOffsets(documentText: string): number[] {
 }
 
 function buildNormalizedText(documentText: string): { normalizedText: string; normalizedOffsets: number[] } {
-    let normalizedText = '';
+    let normalizedText: string[] = [];
     const normalizedOffsets: number[] = [];
     let pendingWhitespaceOffset: number | undefined;
 
@@ -333,16 +333,16 @@ function buildNormalizedText(documentText: string): { normalizedText: string; no
             && !isNormalizedPunctuation(previousCharacter)
             && !isNormalizedPunctuation(character)
         ) {
-            normalizedText += ' ';
+            normalizedText.push(' ');
             normalizedOffsets.push(pendingWhitespaceOffset);
         }
 
-        normalizedText += character;
+        normalizedText.push(character);
         normalizedOffsets.push(index);
         pendingWhitespaceOffset = undefined;
     }
 
-    return { normalizedText, normalizedOffsets };
+    return { normalizedText: normalizedText.join(''), normalizedOffsets };
 }
 
 function clampStoredRange(range: vscode.Range, documentText: string, lineOffsets: number[]): { startOffset: number; endOffset: number } {


### PR DESCRIPTION
Hi,

there was performances issues for my project. When using annotations on large files, the extension was unusable.
With this fix, it's now performant, even on very large file (more than 200k lines).

+= operator on strings in a loop should be avoided.
It's preferable to use arrays and join('') to reduce reallocations of immutable strings over and over again.

Otherwise it's a nice plugin. I'll probably add more features in my fork, like annotation templates from a .json file because I have no uses for the hardcoded AI-specific ones.