### PR TITLE
feat: add local diff review functionality

### DIFF
--- a/media/plan-review-webview.css
+++ b/media/plan-review-webview.css
@@ -60,7 +60,8 @@ body {
 .hero-meta,
 .section-meta,
 .annotation-meta,
-.block-lines {
+.block-lines,
+.diff-file-meta {
   margin: 6px 0 0;
   color: var(--vscode-descriptionForeground);
   font-size: 12px;
@@ -96,6 +97,17 @@ body {
 .block-list {
   display: grid;
   gap: 12px;
+}
+
+.diff-file-meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.diff-code {
+  font-family: var(--vscode-editor-font-family, var(--vscode-font-family));
 }
 
 .section-card__header,

--- a/media/plan-review-webview.js
+++ b/media/plan-review-webview.js
@@ -4,12 +4,18 @@
     const root = document.getElementById('plan-review-root');
     const categoryLabels = {
         approve_note: 'Approve Note',
+        bug_risk: 'Bug Risk',
         comment: 'Comment',
+        follow_up: 'Follow Up',
+        maintainability: 'Maintainability',
+        performance: 'Performance',
         request_change: 'Request Change',
         missing_step: 'Missing Step',
         risk: 'Risk',
+        security: 'Security',
         replacement: 'Replacement',
         suggested_replacement: 'Suggested Replacement',
+        test_gap: 'Test Gap',
         question: 'Question',
         global_comment: 'Global Comment'
     };
@@ -29,8 +35,8 @@
         localDiff: {
             eyebrow: 'Persisted Local Diff Review',
             emptyStateTitle: 'No local diff review loaded',
-            globalActionLabel: 'Add Comment',
-            globalHeading: 'Artifact Comments'
+            globalActionLabel: 'Add Review Note',
+            globalHeading: 'Artifact Notes'
         }
     };
     let artifact = stateElement ? JSON.parse(stateElement.textContent || 'null') : null;
@@ -71,6 +77,18 @@
         });
     }
 
+    function getAnnotationsForDiffFile(diffFileId) {
+        return artifact.annotations.filter(function (annotation) {
+            return annotation.target.type === 'diffFile' && annotation.target.diffFileId === diffFileId;
+        });
+    }
+
+    function getAnnotationsForDiffHunk(diffHunkId) {
+        return artifact.annotations.filter(function (annotation) {
+            return annotation.target.type === 'diffHunk' && annotation.target.diffHunkId === diffHunkId;
+        });
+    }
+
     function getGlobalAnnotations() {
         return artifact.annotations.filter(function (annotation) {
             return annotation.target.type === 'artifact';
@@ -96,6 +114,12 @@
         }
         if (annotation.target.type === 'section' && annotation.target.sectionId) {
             return 'Section ' + annotation.target.sectionId;
+        }
+        if (annotation.target.type === 'diffFile' && annotation.target.diffFileId) {
+            return 'Diff File ' + annotation.target.diffFileId;
+        }
+        if (annotation.target.type === 'diffHunk' && annotation.target.diffHunkId) {
+            return 'Diff Hunk ' + annotation.target.diffHunkId;
         }
         return 'Artifact';
     }
@@ -164,6 +188,131 @@
         ].join('');
     }
 
+    function getSourceBasePath() {
+        if (!artifact || !artifact.source) {
+            return '';
+        }
+
+        return String(
+            (artifact.source.metadata && artifact.source.metadata.repositoryRoot)
+            || artifact.source.workspaceFolder
+            || ''
+        );
+    }
+
+    function getDiffSourcePath(diffFile) {
+        if (diffFile.status === 'deleted') {
+            return diffFile.oldPath || diffFile.newPath || '';
+        }
+
+        return diffFile.newPath || diffFile.oldPath || '';
+    }
+
+    function getDiffOpenRange(diffFile, hunk) {
+        if (!hunk) {
+            const firstHunk = diffFile.hunks && diffFile.hunks.length > 0 ? diffFile.hunks[0] : undefined;
+            if (!firstHunk) {
+                return { lineStart: 1, lineEnd: 1 };
+            }
+
+            return getDiffOpenRange(diffFile, firstHunk);
+        }
+
+        const usesOldRange = diffFile.status === 'deleted';
+        const lineStart = usesOldRange ? hunk.oldStart : hunk.newStart;
+        const lineCount = usesOldRange ? hunk.oldLines : hunk.newLines;
+        return {
+            lineStart: lineStart || 1,
+            lineEnd: Math.max(lineStart || 1, (lineStart || 1) + Math.max((lineCount || 1) - 1, 0))
+        };
+    }
+
+    function renderDiffLines(hunk) {
+        return hunk.lines.map(function (line) {
+            const prefix = line.type === 'add' ? '+' : (line.type === 'delete' ? '-' : ' ');
+            return prefix + line.content;
+        }).join('\n');
+    }
+
+    function renderDiffHunk(diffFile, hunk) {
+        const annotations = getAnnotationsForDiffHunk(hunk.id);
+        const sourcePath = getDiffSourcePath(diffFile);
+        const sourceBasePath = getSourceBasePath();
+        const range = getDiffOpenRange(diffFile, hunk);
+
+        return [
+            '<div class="block-card diff-hunk-card">',
+            '<div class="block-card__header">',
+            '<div>',
+            '<span class="badge">Hunk</span>',
+            '<span class="block-lines">' + escapeHtml(hunk.header) + '</span>',
+            '</div>',
+            '<div class="section-actions">',
+            sourcePath ? '<button class="secondary" data-command="openSource" data-source-path="' + escapeHtml(sourcePath) + '" data-source-base-path="' + escapeHtml(sourceBasePath) + '" data-line-start="' + escapeHtml(range.lineStart) + '" data-line-end="' + escapeHtml(range.lineEnd) + '">Open Source</button>' : '',
+            '<button class="primary" data-command="addAnnotation" data-target-type="diffHunk" data-diff-file-id="' + escapeHtml(diffFile.id) + '" data-diff-hunk-id="' + escapeHtml(hunk.id) + '" data-line-start="' + escapeHtml(range.lineStart) + '" data-line-end="' + escapeHtml(range.lineEnd) + '">Add Annotation</button>',
+            '</div>',
+            '</div>',
+            '<pre class="block-content diff-code">' + escapeHtml(renderDiffLines(hunk)) + '</pre>',
+            annotations.length > 0 ? '<div class="annotation-list">' + annotations.map(renderAnnotation).join('') + '</div>' : '',
+            '</div>'
+        ].join('');
+    }
+
+    function renderDiffFile(diffFile) {
+        const annotations = getAnnotationsForDiffFile(diffFile.id);
+        const sourcePath = getDiffSourcePath(diffFile);
+        const sourceBasePath = getSourceBasePath();
+        const range = getDiffOpenRange(diffFile);
+        const metadata = diffFile.metadata || {};
+
+        return [
+            '<section class="section-card diff-file-card">',
+            '<div class="section-card__header">',
+            '<div>',
+            '<h2>' + escapeHtml(diffFile.newPath || diffFile.oldPath || diffFile.id) + '</h2>',
+            '<p class="section-meta">Status ' + escapeHtml(diffFile.status) + ' • ' + escapeHtml(metadata.hunkCount || diffFile.hunks.length) + ' hunks • +' + escapeHtml(metadata.addedLineCount || 0) + ' / -' + escapeHtml(metadata.deletedLineCount || 0) + '</p>',
+            '</div>',
+            '<div class="section-actions">',
+            sourcePath ? '<button class="secondary" data-command="openSource" data-source-path="' + escapeHtml(sourcePath) + '" data-source-base-path="' + escapeHtml(sourceBasePath) + '" data-line-start="' + escapeHtml(range.lineStart) + '" data-line-end="' + escapeHtml(range.lineEnd) + '">Open Source</button>' : '',
+            '<button class="primary" data-command="addAnnotation" data-target-type="diffFile" data-diff-file-id="' + escapeHtml(diffFile.id) + '">Add Annotation</button>',
+            '</div>',
+            '</div>',
+            '<div class="diff-file-meta">',
+            '<span class="badge badge--category">' + escapeHtml(diffFile.status) + '</span>',
+            '<span class="block-lines">Old ' + escapeHtml(diffFile.oldPath || 'n/a') + '</span>',
+            '<span class="block-lines">New ' + escapeHtml(diffFile.newPath || 'n/a') + '</span>',
+            '</div>',
+            annotations.length > 0 ? '<div class="annotation-list">' + annotations.map(renderAnnotation).join('') + '</div>' : '',
+            '<div class="block-list">' + diffFile.hunks.map(function (hunk) { return renderDiffHunk(diffFile, hunk); }).join('') + '</div>',
+            '</section>'
+        ].join('');
+    }
+
+    function buildStatCards(config) {
+        if (artifact.kind === 'localDiff') {
+            const diffFiles = artifact.content.diffFiles || [];
+            const hunkCount = diffFiles.reduce(function (count, diffFile) {
+                return count + diffFile.hunks.length;
+            }, 0);
+
+            return [
+                { label: 'Diff Files', value: diffFiles.length },
+                { label: 'Hunks', value: hunkCount },
+                { label: 'Annotations', value: artifact.annotations.length },
+                { label: 'Open', value: artifact.annotations.filter(function (annotation) { return annotation.status === 'open'; }).length },
+                { label: 'Exports', value: artifact.exportState && artifact.exportState.exports ? artifact.exportState.exports.length : 0 }
+            ];
+        }
+
+        return [
+            { label: 'Sections', value: (artifact.content.sections || []).length },
+            { label: 'Blocks', value: (artifact.content.blocks || []).length },
+            { label: 'Annotations', value: artifact.annotations.length },
+            { label: 'Open', value: artifact.annotations.filter(function (annotation) { return annotation.status === 'open'; }).length },
+            { label: 'Exports', value: artifact.exportState && artifact.exportState.exports ? artifact.exportState.exports.length : 0 }
+        ];
+    }
+
     function render() {
         const config = getArtifactConfig();
 
@@ -173,12 +322,9 @@
         }
 
         const sections = artifact.content.sections || [];
-        const blocks = artifact.content.blocks || [];
+        const diffFiles = artifact.content.diffFiles || [];
         const globalAnnotations = getGlobalAnnotations();
-        const exportCount = artifact.exportState && artifact.exportState.exports ? artifact.exportState.exports.length : 0;
-        const openCount = artifact.annotations.filter(function (annotation) {
-            return annotation.status === 'open';
-        }).length;
+        const statCards = buildStatCards(config);
 
         root.innerHTML = [
             '<main class="page">',
@@ -196,15 +342,13 @@
             artifact.source.uri && artifact.source.uri.indexOf('file:') === 0 ? '<button class="secondary" data-command="openSource" data-line-start="1" data-line-end="1">Open Source</button>' : '',
             '</div>',
             '</header>',
-            '<section class="stats-grid">',
-            '<article class="stat-card"><span class="stat-label">Sections</span><strong>' + escapeHtml(sections.length) + '</strong></article>',
-            '<article class="stat-card"><span class="stat-label">Blocks</span><strong>' + escapeHtml(blocks.length) + '</strong></article>',
-            '<article class="stat-card"><span class="stat-label">Annotations</span><strong>' + escapeHtml(artifact.annotations.length) + '</strong></article>',
-            '<article class="stat-card"><span class="stat-label">Open</span><strong>' + escapeHtml(openCount) + '</strong></article>',
-            '<article class="stat-card"><span class="stat-label">Exports</span><strong>' + escapeHtml(exportCount) + '</strong></article>',
-            '</section>',
+            '<section class="stats-grid">' + statCards.map(function (card) {
+                return '<article class="stat-card"><span class="stat-label">' + escapeHtml(card.label) + '</span><strong>' + escapeHtml(card.value) + '</strong></article>';
+            }).join('') + '</section>',
             globalAnnotations.length > 0 ? '<section class="global-annotations"><h2>' + escapeHtml(config.globalHeading) + '</h2><div class="annotation-list">' + globalAnnotations.map(renderAnnotation).join('') + '</div></section>' : '',
-            '<section class="sections">' + sections.map(renderSection).join('') + '</section>',
+            artifact.kind === 'localDiff'
+                ? '<section class="sections">' + diffFiles.map(renderDiffFile).join('') + '</section>'
+                : '<section class="sections">' + sections.map(renderSection).join('') + '</section>',
             '</main>'
         ].join('');
     }
@@ -229,8 +373,12 @@
             targetType: button.getAttribute('data-target-type') || undefined,
             sectionId: button.getAttribute('data-section-id') || undefined,
             blockId: button.getAttribute('data-block-id') || undefined,
+            diffFileId: button.getAttribute('data-diff-file-id') || undefined,
+            diffHunkId: button.getAttribute('data-diff-hunk-id') || undefined,
             lineStart: button.getAttribute('data-line-start') ? Number(button.getAttribute('data-line-start')) : undefined,
-            lineEnd: button.getAttribute('data-line-end') ? Number(button.getAttribute('data-line-end')) : undefined
+            lineEnd: button.getAttribute('data-line-end') ? Number(button.getAttribute('data-line-end')) : undefined,
+            sourcePath: button.getAttribute('data-source-path') || undefined,
+            sourceBasePath: button.getAttribute('data-source-base-path') || undefined
         };
 
         vscode.postMessage(message);

--- a/package.json
+++ b/package.json
@@ -201,6 +201,11 @@
         "command": "annotative.reviewLastAIResponse",
         "title": "Annotative: Review Last AI Response",
         "icon": "$(comment-discussion)"
+      },
+      {
+        "command": "annotative.reviewLocalDiff",
+        "title": "Annotative: Review Local Diff",
+        "icon": "$(diff-multiple)"
       }
     ],
     "viewsContainers": {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode';
-import { AiResponseReviewService, AnnotationManager, MarkdownPlanReviewService, ReviewArtifactManager } from '../managers';
+import { AiResponseReviewService, AnnotationManager, LocalDiffReviewService, MarkdownPlanReviewService, ReviewArtifactManager } from '../managers';
 import { AnnotationProvider, PlanReviewPanel, SidebarWebview } from '../ui';
 
 export type CommandContext = {
@@ -13,6 +13,7 @@ export type CommandContext = {
     annotationProvider?: AnnotationProvider;
     reviewArtifactManager?: ReviewArtifactManager;
     aiResponseReviewService?: AiResponseReviewService;
+    localDiffReviewService?: LocalDiffReviewService;
     markdownPlanReviewService?: MarkdownPlanReviewService;
     planReviewPanel?: PlanReviewPanel;
     ANNOTATION_COLORS: Array<{ label: string; value: string }>;
@@ -23,6 +24,7 @@ export { registerAnnotationCommands } from './annotation';
 export { registerAiResponseReviewCommands } from './aiResponseReview';
 export { registerExportCommands } from './export';
 export { registerFilterCommands } from './filters';
+export { registerLocalDiffReviewCommands } from './localDiffReview';
 export { registerNavigationCommands } from './navigation';
 export { registerPlanReviewCommands } from './planReview';
 export { registerSidebarCommands } from './sidebar';

--- a/src/commands/localDiffReview.ts
+++ b/src/commands/localDiffReview.ts
@@ -1,0 +1,31 @@
+import * as vscode from 'vscode';
+import { CommandContext } from './index';
+
+export function registerLocalDiffReviewCommands(
+    _context: vscode.ExtensionContext,
+    cmdContext: CommandContext
+) {
+    const { localDiffReviewService, planReviewPanel } = cmdContext;
+
+    if (!localDiffReviewService || !planReviewPanel) {
+        return {};
+    }
+
+    const reviewLocalDiffCommand = vscode.commands.registerCommand(
+        'annotative.reviewLocalDiff',
+        async () => {
+            try {
+                const artifact = await localDiffReviewService.createArtifactFromWorkspaceDiff();
+                await planReviewPanel.showArtifact(artifact.id);
+                vscode.window.showInformationMessage(`Local diff review created: ${artifact.title}`);
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                vscode.window.showErrorMessage(`Failed to review local diff: ${message}`);
+            }
+        }
+    );
+
+    return {
+        reviewLocalDiffCommand,
+    };
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { AiResponseReviewService, AnnotationManager, MarkdownPlanReviewService, ReviewArtifactManager } from './managers';
+import { AiResponseReviewService, AnnotationManager, LocalDiffReviewService, MarkdownPlanReviewService, ReviewArtifactManager } from './managers';
 import { PlanReviewPanel, SidebarWebview } from './ui';
 import { registerChatParticipant, registerChatVariableIfAvailable } from './copilotChatParticipant';
 import {
@@ -7,6 +7,7 @@ import {
     registerAiResponseReviewCommands,
     registerExportCommands,
     registerFilterCommands,
+    registerLocalDiffReviewCommands,
     registerNavigationCommands,
     registerPlanReviewCommands,
     registerSidebarCommands,
@@ -30,6 +31,7 @@ let annotationManager: AnnotationManager;
 let sidebarWebview: SidebarWebview;
 let reviewArtifactManager: ReviewArtifactManager;
 let aiResponseReviewService: AiResponseReviewService;
+let localDiffReviewService: LocalDiffReviewService;
 let markdownPlanReviewService: MarkdownPlanReviewService;
 let planReviewPanel: PlanReviewPanel;
 
@@ -38,6 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
     annotationManager = new AnnotationManager(context);
     reviewArtifactManager = new ReviewArtifactManager();
     aiResponseReviewService = new AiResponseReviewService(reviewArtifactManager);
+    localDiffReviewService = new LocalDiffReviewService(reviewArtifactManager);
     markdownPlanReviewService = new MarkdownPlanReviewService(reviewArtifactManager);
     sidebarWebview = new SidebarWebview(context.extensionUri, annotationManager);
     planReviewPanel = new PlanReviewPanel(context.extensionUri, reviewArtifactManager);
@@ -72,6 +75,7 @@ export function activate(context: vscode.ExtensionContext) {
         sidebarWebview,
         reviewArtifactManager,
         aiResponseReviewService,
+        localDiffReviewService,
         markdownPlanReviewService,
         planReviewPanel,
         ANNOTATION_COLORS
@@ -83,6 +87,7 @@ export function activate(context: vscode.ExtensionContext) {
         ...Object.values(registerAiResponseReviewCommands(context, cmdContext)),
         ...Object.values(registerExportCommands(context, cmdContext)),
         ...Object.values(registerFilterCommands(context, cmdContext)),
+        ...Object.values(registerLocalDiffReviewCommands(context, cmdContext)),
         ...Object.values(registerNavigationCommands(context, cmdContext)),
         ...Object.values(registerPlanReviewCommands(context, cmdContext)),
         ...Object.values(registerSidebarCommands(context, cmdContext)),

--- a/src/managers/index.ts
+++ b/src/managers/index.ts
@@ -15,6 +15,12 @@ export {
 	type CreateAiResponseArtifactInput,
 } from './aiResponseReviewService';
 export {
+	LocalDiffReviewService,
+	parseUnifiedDiff,
+	type CreateLocalDiffArtifactInput,
+	type ParsedLocalDiff,
+} from './localDiffReviewService';
+export {
 	MarkdownPlanReviewService,
 	parseMarkdownPlan,
 	parseStructuredMarkdownContent,

--- a/src/managers/localDiffReviewService.ts
+++ b/src/managers/localDiffReviewService.ts
@@ -1,0 +1,394 @@
+import { execFile } from 'child_process';
+import * as path from 'path';
+import { promisify } from 'util';
+import * as vscode from 'vscode';
+import {
+    ReviewArtifact,
+    ReviewArtifactDiffFile,
+    ReviewArtifactDiffFileStatus,
+    ReviewArtifactDiffHunk,
+    ReviewArtifactDiffLine,
+    ReviewArtifactMetadata,
+    ReviewArtifactSource,
+} from '../types';
+import { getPreferredWorkspaceFolder } from '../utils/workspaceContext';
+import { ReviewArtifactManager } from './reviewArtifactManager';
+
+const execFileAsync = promisify(execFile);
+const LOCAL_DIFF_PARSER_ID = 'gitUnifiedDiffV1';
+const DEFAULT_CONTEXT_LINES = 3;
+
+export interface CreateLocalDiffArtifactInput {
+    rawDiff: string;
+    title?: string;
+    source: ReviewArtifactSource;
+}
+
+export interface ParsedLocalDiff {
+    diffFiles: ReviewArtifactDiffFile[];
+    metadata: ReviewArtifactMetadata;
+}
+
+export interface LocalDiffReviewServiceOptions {
+    runGitCommand?: (cwd: string, args: string[]) => Promise<string>;
+    resolveWorkspaceFolder?: () => vscode.WorkspaceFolder | undefined;
+}
+
+interface MutableDiffHunk {
+    hunk: ReviewArtifactDiffHunk;
+    nextOldLine: number;
+    nextNewLine: number;
+}
+
+export class LocalDiffReviewService {
+    private readonly runGitCommand: (cwd: string, args: string[]) => Promise<string>;
+    private readonly resolveWorkspaceFolder: () => vscode.WorkspaceFolder | undefined;
+
+    constructor(
+        private readonly reviewArtifactManager: ReviewArtifactManager,
+        options: LocalDiffReviewServiceOptions = {}
+    ) {
+        this.runGitCommand = options.runGitCommand ?? runGitCommand;
+        this.resolveWorkspaceFolder = options.resolveWorkspaceFolder ?? getPreferredWorkspaceFolder;
+    }
+
+    async createArtifactFromWorkspaceDiff(workspaceFolder = this.resolveWorkspaceFolder()): Promise<ReviewArtifact> {
+        if (!workspaceFolder) {
+            throw new Error('Open a workspace folder before reviewing local changes.');
+        }
+
+        const repositoryRoot = (await this.runGitCommand(workspaceFolder.uri.fsPath, ['rev-parse', '--show-toplevel'])).trim();
+        if (!repositoryRoot) {
+            throw new Error('Unable to determine the git repository root for the current workspace.');
+        }
+
+        const revision = await this.getCurrentRevision(repositoryRoot);
+
+        // MVP snapshot strategy: compare HEAD to the current tracked working tree so staged and unstaged
+        // tracked changes land in one persisted artifact. Untracked files remain out of scope for Phase 5.
+        const diffArgs = revision
+            ? ['diff', '--no-ext-diff', '--minimal', `--unified=${DEFAULT_CONTEXT_LINES}`, 'HEAD', '--']
+            : ['diff', '--no-ext-diff', '--minimal', `--unified=${DEFAULT_CONTEXT_LINES}`, '--'];
+        const rawDiff = normalizeDiffText(await this.runGitCommand(repositoryRoot, diffArgs));
+
+        if (rawDiff.length === 0) {
+            throw new Error('No tracked local changes were found in the current workspace.');
+        }
+
+        return this.createArtifactFromDiff({
+            rawDiff,
+            source: {
+                type: 'gitDiff',
+                workspaceFolder: workspaceFolder.uri.fsPath,
+                revision,
+                metadata: {
+                    contextLines: DEFAULT_CONTEXT_LINES,
+                    includesStagedChanges: Boolean(revision),
+                    includesUntrackedFiles: false,
+                    parser: LOCAL_DIFF_PARSER_ID,
+                    repositoryRoot,
+                    snapshotMode: revision ? 'headToWorkingTreeTracked' : 'workingTreeTracked',
+                    trackedFilesOnly: true,
+                },
+            },
+        });
+    }
+
+    async createArtifactFromDiff(input: CreateLocalDiffArtifactInput): Promise<ReviewArtifact> {
+        const normalizedDiff = normalizeDiffText(input.rawDiff);
+        if (normalizedDiff.length === 0) {
+            throw new Error('Local diff content cannot be empty.');
+        }
+
+        const parsed = parseUnifiedDiff(normalizedDiff);
+
+        return this.reviewArtifactManager.createAndSaveArtifact({
+            kind: 'localDiff',
+            title: input.title?.trim() || deriveTitleFromSource(input.source),
+            source: input.source,
+            content: {
+                rawText: normalizedDiff,
+                diffFiles: parsed.diffFiles,
+                metadata: parsed.metadata,
+            },
+        });
+    }
+
+    private async getCurrentRevision(repositoryRoot: string): Promise<string | undefined> {
+        try {
+            const revision = (await this.runGitCommand(repositoryRoot, ['rev-parse', '--verify', 'HEAD'])).trim();
+            return revision || undefined;
+        } catch {
+            return undefined;
+        }
+    }
+}
+
+export function parseUnifiedDiff(rawDiff: string): ParsedLocalDiff {
+    const normalizedDiff = normalizeDiffText(rawDiff);
+    if (normalizedDiff.length === 0) {
+        throw new Error('Local diff content cannot be empty.');
+    }
+
+    const lines = normalizedDiff.split('\n');
+    const diffFiles: ReviewArtifactDiffFile[] = [];
+    let currentFile: ReviewArtifactDiffFile | undefined;
+    let currentHunk: MutableDiffHunk | undefined;
+
+    const finalizeCurrentHunk = () => {
+        if (!currentFile || !currentHunk) {
+            return;
+        }
+
+        currentFile.hunks.push(currentHunk.hunk);
+        currentHunk = undefined;
+    };
+
+    const finalizeCurrentFile = () => {
+        finalizeCurrentHunk();
+        if (!currentFile) {
+            return;
+        }
+
+        currentFile.metadata = {
+            addedLineCount: countDiffLines(currentFile.hunks, 'add'),
+            deletedLineCount: countDiffLines(currentFile.hunks, 'delete'),
+            hunkCount: currentFile.hunks.length,
+        };
+        diffFiles.push(currentFile);
+        currentFile = undefined;
+    };
+
+    for (const line of lines) {
+        if (line.startsWith('diff --git ')) {
+            finalizeCurrentFile();
+            const paths = parseDiffGitPaths(line);
+            currentFile = {
+                id: createDiffFileId(paths?.newPath ?? paths?.oldPath ?? `file-${diffFiles.length + 1}`),
+                oldPath: paths?.oldPath ?? '',
+                newPath: paths?.newPath ?? '',
+                status: 'modified',
+                hunks: [],
+            };
+            continue;
+        }
+
+        if (!currentFile) {
+            continue;
+        }
+
+        if (line.startsWith('new file mode ')) {
+            currentFile.status = 'added';
+            continue;
+        }
+
+        if (line.startsWith('deleted file mode ')) {
+            currentFile.status = 'deleted';
+            continue;
+        }
+
+        if (line.startsWith('rename from ')) {
+            currentFile.status = 'renamed';
+            currentFile.oldPath = line.slice('rename from '.length).trim();
+            continue;
+        }
+
+        if (line.startsWith('rename to ')) {
+            currentFile.status = 'renamed';
+            currentFile.newPath = line.slice('rename to '.length).trim();
+            continue;
+        }
+
+        if (line.startsWith('copy from ')) {
+            currentFile.status = 'copied';
+            currentFile.oldPath = line.slice('copy from '.length).trim();
+            continue;
+        }
+
+        if (line.startsWith('copy to ')) {
+            currentFile.status = 'copied';
+            currentFile.newPath = line.slice('copy to '.length).trim();
+            continue;
+        }
+
+        if (line.startsWith('--- ')) {
+            const oldPath = parseHeaderPath(line.slice(4));
+            if (oldPath) {
+                currentFile.oldPath = oldPath;
+            }
+            continue;
+        }
+
+        if (line.startsWith('+++ ')) {
+            const newPath = parseHeaderPath(line.slice(4));
+            if (newPath) {
+                currentFile.newPath = newPath;
+            }
+            continue;
+        }
+
+        const hunkMatch = line.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/);
+        if (hunkMatch) {
+            finalizeCurrentHunk();
+            const oldStart = Number.parseInt(hunkMatch[1], 10);
+            const oldLines = Number.parseInt(hunkMatch[2] ?? '1', 10);
+            const newStart = Number.parseInt(hunkMatch[3], 10);
+            const newLines = Number.parseInt(hunkMatch[4] ?? '1', 10);
+            const hunkIndex = currentFile.hunks.length + 1;
+
+            currentHunk = {
+                hunk: {
+                    id: `${currentFile.id}-hunk-${hunkIndex}`,
+                    header: `@@ -${oldStart},${oldLines} +${newStart},${newLines} @@${hunkMatch[5] ?? ''}`,
+                    oldStart,
+                    oldLines,
+                    newStart,
+                    newLines,
+                    lines: [],
+                },
+                nextOldLine: oldStart,
+                nextNewLine: newStart,
+            };
+            continue;
+        }
+
+        if (!currentHunk || line.startsWith('\\ No newline at end of file')) {
+            continue;
+        }
+
+        const parsedLine = parseDiffLine(line, currentHunk);
+        if (parsedLine) {
+            currentHunk.hunk.lines.push(parsedLine);
+        }
+    }
+
+    finalizeCurrentFile();
+
+    const totalHunks = diffFiles.reduce((count, diffFile) => count + diffFile.hunks.length, 0);
+    const addedLineCount = diffFiles.reduce(
+        (count, diffFile) => count + countDiffLines(diffFile.hunks, 'add'),
+        0
+    );
+    const deletedLineCount = diffFiles.reduce(
+        (count, diffFile) => count + countDiffLines(diffFile.hunks, 'delete'),
+        0
+    );
+
+    return {
+        diffFiles,
+        metadata: {
+            addedLineCount,
+            deletedLineCount,
+            diffFileCount: diffFiles.length,
+            hunkCount: totalHunks,
+            parser: LOCAL_DIFF_PARSER_ID,
+        },
+    };
+}
+
+function deriveTitleFromSource(source: ReviewArtifactSource): string {
+    const workspaceFolder = source.workspaceFolder ? path.basename(source.workspaceFolder) : undefined;
+    return workspaceFolder ? `Review Local Diff: ${workspaceFolder}` : 'Review Local Diff';
+}
+
+async function runGitCommand(cwd: string, args: string[]): Promise<string> {
+    const { stdout, stderr } = await execFileAsync('git', args, {
+        cwd,
+        maxBuffer: 10 * 1024 * 1024,
+        windowsHide: true,
+    });
+
+    if (stderr && stderr.trim().length > 0) {
+        return stdout;
+    }
+
+    return stdout;
+}
+
+function normalizeDiffText(value: string): string {
+    return value.replace(/\r\n/g, '\n').trim();
+}
+
+function parseDiffGitPaths(line: string): { oldPath: string; newPath: string } | undefined {
+    const match = line.match(/^diff --git a\/(.+) b\/(.+)$/);
+    if (!match) {
+        return undefined;
+    }
+
+    return {
+        oldPath: match[1],
+        newPath: match[2],
+    };
+}
+
+function parseHeaderPath(value: string): string | undefined {
+    const trimmed = value.trim().replace(/^"|"$/g, '');
+    if (trimmed === '/dev/null') {
+        return undefined;
+    }
+
+    if (trimmed.startsWith('a/')) {
+        return trimmed.slice(2);
+    }
+
+    if (trimmed.startsWith('b/')) {
+        return trimmed.slice(2);
+    }
+
+    return trimmed;
+}
+
+function createDiffFileId(filePath: string): string {
+    const slug = filePath
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+    return slug ? `diff-file-${slug}` : 'diff-file';
+}
+
+function countDiffLines(hunks: ReviewArtifactDiffHunk[], type: ReviewArtifactDiffLine['type']): number {
+    return hunks.reduce(
+        (count, hunk) => count + hunk.lines.filter(line => line.type === type).length,
+        0
+    );
+}
+
+function parseDiffLine(line: string, currentHunk: MutableDiffHunk): ReviewArtifactDiffLine | undefined {
+    const indicator = line[0];
+    const content = line.slice(1);
+
+    switch (indicator) {
+        case '+': {
+            const parsedLine: ReviewArtifactDiffLine = {
+                type: 'add',
+                content,
+                newLineNumber: currentHunk.nextNewLine,
+            };
+            currentHunk.nextNewLine += 1;
+            return parsedLine;
+        }
+        case '-': {
+            const parsedLine: ReviewArtifactDiffLine = {
+                type: 'delete',
+                content,
+                oldLineNumber: currentHunk.nextOldLine,
+            };
+            currentHunk.nextOldLine += 1;
+            return parsedLine;
+        }
+        case ' ': {
+            const parsedLine: ReviewArtifactDiffLine = {
+                type: 'context',
+                content,
+                oldLineNumber: currentHunk.nextOldLine,
+                newLineNumber: currentHunk.nextNewLine,
+            };
+            currentHunk.nextOldLine += 1;
+            currentHunk.nextNewLine += 1;
+            return parsedLine;
+        }
+        default:
+            return undefined;
+    }
+}

--- a/src/managers/reviewArtifactExportService.ts
+++ b/src/managers/reviewArtifactExportService.ts
@@ -588,6 +588,7 @@ function isRequestedChange(annotation: ReviewAnnotation): boolean {
     return annotation.kind === 'requestChange'
         || annotation.kind === 'maintainability'
         || annotation.metadata?.category === 'request_change'
+    || annotation.metadata?.category === 'maintainability'
         || annotation.metadata?.category === 'replacement'
         || annotation.metadata?.category === 'suggested_replacement';
 }
@@ -597,7 +598,12 @@ function isMissingStep(annotation: ReviewAnnotation): boolean {
 }
 
 function isRiskOrConcern(annotation: ReviewAnnotation): boolean {
-    return annotation.kind === 'risk' || annotation.kind === 'testGap';
+    return annotation.kind === 'risk'
+        || annotation.kind === 'testGap'
+        || annotation.metadata?.category === 'bug_risk'
+        || annotation.metadata?.category === 'performance'
+        || annotation.metadata?.category === 'security'
+        || annotation.metadata?.category === 'test_gap';
 }
 
 function buildCopilotNextSteps(
@@ -631,6 +637,23 @@ function buildCopilotNextSteps(
 }
 
 function formatAnnotationLabel(annotation: ReviewAnnotation): string {
+    switch (annotation.metadata?.category) {
+        case 'bug_risk':
+            return 'Bug Risk';
+        case 'follow_up':
+            return 'Follow Up';
+        case 'maintainability':
+            return 'Maintainability';
+        case 'performance':
+            return 'Performance';
+        case 'security':
+            return 'Security';
+        case 'test_gap':
+            return 'Test Gap';
+        default:
+            break;
+    }
+
     if (annotation.metadata?.category === 'replacement' || annotation.metadata?.category === 'suggested_replacement') {
         return 'Suggested Replacement';
     }

--- a/src/test/suite/localDiffReviewCommand.test.ts
+++ b/src/test/suite/localDiffReviewCommand.test.ts
@@ -1,0 +1,69 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { registerLocalDiffReviewCommands } from '../../commands';
+
+type RegisteredCommandCallback = (...args: unknown[]) => Promise<void> | void;
+
+suite('LocalDiffReviewCommands', () => {
+    const originalRegisterCommand = vscode.commands.registerCommand;
+    const originalShowInformationMessage = vscode.window.showInformationMessage;
+    const originalShowErrorMessage = vscode.window.showErrorMessage;
+
+    teardown(() => {
+        (vscode.commands as unknown as { registerCommand: typeof vscode.commands.registerCommand }).registerCommand = originalRegisterCommand;
+        (vscode.window as unknown as { showInformationMessage: typeof vscode.window.showInformationMessage }).showInformationMessage = originalShowInformationMessage;
+        (vscode.window as unknown as { showErrorMessage: typeof vscode.window.showErrorMessage }).showErrorMessage = originalShowErrorMessage;
+    });
+
+    test('creates a local diff review artifact from the shared command flow', async () => {
+        const registered = new Map<string, RegisteredCommandCallback>();
+        const calls = {
+            createArtifactFromWorkspaceDiff: 0,
+            showArtifact: [] as string[],
+            infoMessages: [] as string[],
+        };
+        const localDiffReviewService = {
+            createArtifactFromWorkspaceDiff: async () => {
+                calls.createArtifactFromWorkspaceDiff += 1;
+                return { id: 'local-diff-command', title: 'Review Local Diff: Annotative' };
+            },
+        };
+        const planReviewPanel = {
+            showArtifact: async (artifactId: string) => {
+                calls.showArtifact.push(artifactId);
+            },
+        };
+
+        (vscode.commands as unknown as { registerCommand: typeof vscode.commands.registerCommand }).registerCommand =
+            ((command: string, callback: RegisteredCommandCallback) => {
+                registered.set(command, callback);
+                return new vscode.Disposable(() => {
+                    registered.delete(command);
+                });
+            }) as typeof vscode.commands.registerCommand;
+        (vscode.window as unknown as { showInformationMessage: typeof vscode.window.showInformationMessage }).showInformationMessage =
+            (async (message: string) => {
+                calls.infoMessages.push(message);
+                return undefined;
+            }) as typeof vscode.window.showInformationMessage;
+        (vscode.window as unknown as { showErrorMessage: typeof vscode.window.showErrorMessage }).showErrorMessage =
+            (async () => undefined) as typeof vscode.window.showErrorMessage;
+
+        registerLocalDiffReviewCommands({} as vscode.ExtensionContext, {
+            annotationManager: {} as never,
+            sidebarWebview: {} as never,
+            localDiffReviewService: localDiffReviewService as never,
+            planReviewPanel: planReviewPanel as never,
+            ANNOTATION_COLORS: [],
+        });
+
+        const command = registered.get('annotative.reviewLocalDiff');
+        assert.ok(command, 'Expected annotative.reviewLocalDiff to be registered.');
+
+        await command?.();
+
+        assert.strictEqual(calls.createArtifactFromWorkspaceDiff, 1);
+        assert.deepStrictEqual(calls.showArtifact, ['local-diff-command']);
+        assert.deepStrictEqual(calls.infoMessages, ['Local diff review created: Review Local Diff: Annotative']);
+    });
+});

--- a/src/test/suite/localDiffReviewService.test.ts
+++ b/src/test/suite/localDiffReviewService.test.ts
@@ -1,0 +1,109 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { LocalDiffReviewService, ReviewArtifactManager, parseUnifiedDiff } from '../../managers';
+import {
+    clearTestWorkspace,
+    getWorkspaceRoot,
+    readReviewArtifactFixture,
+} from './testUtils';
+
+suite('LocalDiffReviewService', () => {
+    setup(async () => {
+        await clearTestWorkspace();
+    });
+
+    teardown(async () => {
+        await clearTestWorkspace();
+    });
+
+    test('parses unified git diffs into deterministic file and hunk targets', async () => {
+        const rawDiff = await readReviewArtifactFixture('local-diff-basic.diff');
+
+        const parsed = parseUnifiedDiff(rawDiff);
+
+        assert.deepStrictEqual(
+            parsed.diffFiles.map(diffFile => ({
+                id: diffFile.id,
+                oldPath: diffFile.oldPath,
+                newPath: diffFile.newPath,
+                status: diffFile.status,
+                hunkIds: diffFile.hunks.map(hunk => hunk.id),
+            })),
+            [
+                {
+                    id: 'diff-file-src-managers-reviewartifactmanager-ts',
+                    oldPath: 'src/managers/reviewArtifactManager.ts',
+                    newPath: 'src/managers/reviewArtifactManager.ts',
+                    status: 'modified',
+                    hunkIds: ['diff-file-src-managers-reviewartifactmanager-ts-hunk-1'],
+                },
+                {
+                    id: 'diff-file-src-test-suite-reviewartifactexport-test-ts',
+                    oldPath: 'src/test/suite/reviewArtifactExport.test.ts',
+                    newPath: 'src/test/suite/reviewArtifactExport.test.ts',
+                    status: 'added',
+                    hunkIds: ['diff-file-src-test-suite-reviewartifactexport-test-ts-hunk-1'],
+                },
+            ]
+        );
+        assert.strictEqual(parsed.diffFiles[0].hunks[0].oldStart, 18);
+        assert.strictEqual(parsed.diffFiles[0].hunks[0].newStart, 18);
+        assert.strictEqual(parsed.diffFiles[1].hunks[0].oldStart, 0);
+        assert.strictEqual(parsed.metadata.diffFileCount, 2);
+        assert.strictEqual(parsed.metadata.hunkCount, 2);
+        assert.strictEqual(parsed.metadata.addedLineCount, 11);
+        assert.strictEqual(parsed.metadata.deletedLineCount, 0);
+    });
+
+    test('creates and saves local diff review artifacts from the workspace git snapshot flow', async () => {
+        const rawDiff = await readReviewArtifactFixture('local-diff-basic.diff');
+        const gitCalls: Array<{ cwd: string; args: string[] }> = [];
+        const manager = new ReviewArtifactManager({
+            clock: () => new Date('2026-04-05T15:30:00.000Z'),
+            createId: () => 'local-diff-fixture',
+        });
+        const service = new LocalDiffReviewService(manager, {
+            runGitCommand: async (cwd, args) => {
+                gitCalls.push({ cwd, args });
+
+                if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') {
+                    return `${getWorkspaceRoot()}\n`;
+                }
+
+                if (args[0] === 'rev-parse' && args[1] === '--verify') {
+                    return 'abc123def456\n';
+                }
+
+                if (args[0] === 'diff') {
+                    return rawDiff;
+                }
+
+                throw new Error(`Unexpected git args: ${args.join(' ')}`);
+            },
+        });
+
+        const artifact = await service.createArtifactFromWorkspaceDiff({
+            uri: vscode.Uri.file(getWorkspaceRoot()),
+            index: 0,
+            name: 'workspace',
+        });
+        const stored = await manager.getArtifact(artifact.id);
+
+        assert.strictEqual(artifact.id, 'local-diff-fixture');
+        assert.strictEqual(artifact.kind, 'localDiff');
+        assert.strictEqual(artifact.source.type, 'gitDiff');
+        assert.strictEqual(artifact.source.revision, 'abc123def456');
+        assert.strictEqual(artifact.source.metadata?.snapshotMode, 'headToWorkingTreeTracked');
+        assert.strictEqual(artifact.source.metadata?.trackedFilesOnly, true);
+        assert.strictEqual(artifact.content.diffFiles?.length, 2);
+        assert.ok(stored, 'Expected the saved local diff artifact to be reloadable.');
+        assert.deepStrictEqual(
+            gitCalls.map(call => ({ cwd: call.cwd, args: call.args })),
+            [
+                { cwd: getWorkspaceRoot(), args: ['rev-parse', '--show-toplevel'] },
+                { cwd: getWorkspaceRoot(), args: ['rev-parse', '--verify', 'HEAD'] },
+                { cwd: getWorkspaceRoot(), args: ['diff', '--no-ext-diff', '--minimal', '--unified=3', 'HEAD', '--'] },
+            ]
+        );
+    });
+});

--- a/src/test/suite/planReviewPanel.test.ts
+++ b/src/test/suite/planReviewPanel.test.ts
@@ -329,4 +329,107 @@ suite('PlanReviewPanel', () => {
 
         panel.dispose();
     });
+
+    test('routes diff-hunk annotations through the shared review panel for local diff artifacts', async () => {
+        const panelInstance = new FakePanel();
+        const quickPickResults: Array<Record<string, unknown>> = [
+            {
+                label: 'Test Gap',
+                description: 'Capture missing or weak test coverage',
+                option: {
+                    id: 'test_gap',
+                    label: 'Test Gap',
+                    description: 'Capture missing or weak test coverage',
+                    kind: 'testGap',
+                },
+            },
+            {
+                label: 'High',
+                value: 'high',
+            },
+        ];
+        const artifact = createReviewArtifact({
+            id: 'local-diff-panel',
+            kind: 'localDiff',
+            title: 'Shared Local Diff Review',
+            source: {
+                type: 'gitDiff',
+                workspaceFolder: getWorkspaceRoot(),
+                metadata: { repositoryRoot: getWorkspaceRoot() },
+            },
+            annotations: [],
+            content: {
+                rawText: 'diff --git a/src/example.ts b/src/example.ts',
+                diffFiles: [
+                    {
+                        id: 'diff-file-src-example-ts',
+                        oldPath: 'src/example.ts',
+                        newPath: 'src/example.ts',
+                        status: 'modified',
+                        metadata: { hunkCount: 1, addedLineCount: 1, deletedLineCount: 0 },
+                        hunks: [
+                            {
+                                id: 'diff-file-src-example-ts-hunk-1',
+                                header: '@@ -1,2 +1,3 @@ export function example() {',
+                                oldStart: 1,
+                                oldLines: 2,
+                                newStart: 1,
+                                newLines: 3,
+                                lines: [
+                                    { type: 'context', content: 'export function example() {', oldLineNumber: 1, newLineNumber: 1 },
+                                    { type: 'add', content: '    return true;', newLineNumber: 2 },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+        const calls = {
+            addAnnotation: [] as Array<{ artifactId: string; targetType: string; diffFileId?: string; diffHunkId?: string; severity?: string }>,
+        };
+        const reviewArtifactManager = {
+            getArtifact: async () => artifact,
+            addAnnotation: async (artifactId: string, input: { target: { type: string; diffFileId?: string; diffHunkId?: string }; severity?: string }) => {
+                calls.addAnnotation.push({
+                    artifactId,
+                    targetType: input.target.type,
+                    diffFileId: input.target.diffFileId,
+                    diffHunkId: input.target.diffHunkId,
+                    severity: input.severity,
+                });
+                return artifact;
+            },
+        };
+
+        (vscode.window as unknown as { createWebviewPanel: typeof vscode.window.createWebviewPanel }).createWebviewPanel =
+            (() => panelInstance as unknown as vscode.WebviewPanel);
+        (vscode.window as unknown as { showQuickPick: typeof vscode.window.showQuickPick }).showQuickPick =
+            (async () => quickPickResults.shift()) as typeof vscode.window.showQuickPick;
+        (vscode.window as unknown as { showInputBox: typeof vscode.window.showInputBox }).showInputBox =
+            (async () => 'Add coverage for the diff review creation flow.') as typeof vscode.window.showInputBox;
+
+        const panel = new PlanReviewPanel(vscode.Uri.file(getWorkspaceRoot()), reviewArtifactManager as never);
+
+        await panel.showArtifact('local-diff-panel');
+        await panelInstance.webview.dispatch({
+            command: 'addAnnotation',
+            targetType: 'diffHunk',
+            diffFileId: 'diff-file-src-example-ts',
+            diffHunkId: 'diff-file-src-example-ts-hunk-1',
+            lineStart: 1,
+            lineEnd: 3,
+        });
+
+        assert.strictEqual(panelInstance.title, 'Local Diff Review: Shared Local Diff Review');
+        assert.deepStrictEqual(calls.addAnnotation, [{
+            artifactId: 'local-diff-panel',
+            targetType: 'diffHunk',
+            diffFileId: 'diff-file-src-example-ts',
+            diffHunkId: 'diff-file-src-example-ts-hunk-1',
+            severity: 'high',
+        }]);
+
+        panel.dispose();
+    });
 });

--- a/src/test/suite/reviewArtifactExport.test.ts
+++ b/src/test/suite/reviewArtifactExport.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import {
     CopilotReviewPromptReviewArtifactExportAdapter,
     GenericMarkdownReviewArtifactExportAdapter,
+    parseUnifiedDiff,
     parseMarkdownPlan,
     parseStructuredMarkdownContent,
     ReviewArtifactExportService,
@@ -422,5 +423,65 @@ suite('ReviewArtifactExportService', () => {
         assert.ok(genericExport.content.includes('Suggested replacement:'));
         assert.ok(copilotExport.content.includes('### 1. Suggested Replacement [high]'));
         assert.ok(copilotExport.content.includes('Suggested revision:'));
+    });
+
+    test('exports local diff artifacts with file and hunk references through shared adapters', async () => {
+        const rawDiff = await readReviewArtifactFixture('local-diff-basic.diff');
+        const parsed = parseUnifiedDiff(rawDiff);
+        const artifact = createReviewArtifact({
+            id: 'local-diff-export',
+            kind: 'localDiff',
+            title: 'Review Local Diff: Annotative',
+            source: {
+                type: 'gitDiff',
+                workspaceFolder: 'c:/workspace',
+                revision: 'abc123def456',
+                metadata: {
+                    repositoryRoot: 'c:/workspace',
+                    snapshotMode: 'headToWorkingTreeTracked',
+                    trackedFilesOnly: true,
+                },
+            },
+            content: {
+                rawText: rawDiff,
+                diffFiles: parsed.diffFiles,
+                metadata: parsed.metadata,
+            },
+            annotations: [
+                createReviewAnnotation({
+                    id: 'diff-file-follow-up',
+                    kind: 'comment',
+                    target: { type: 'diffFile', diffFileId: parsed.diffFiles[0].id },
+                    body: 'Follow up on the placeholder workspace export behavior before broadening scope.',
+                    metadata: { category: 'follow_up' },
+                }),
+                createReviewAnnotation({
+                    id: 'diff-hunk-test-gap',
+                    kind: 'testGap',
+                    target: { type: 'diffHunk', diffHunkId: parsed.diffFiles[0].hunks[0].id },
+                    body: 'Add a deterministic test for the new exportArtifactsForWorkspace placeholder branch.',
+                    severity: 'high',
+                    metadata: { category: 'test_gap' },
+                }),
+            ],
+        });
+        const service = new ReviewArtifactExportService([
+            new GenericMarkdownReviewArtifactExportAdapter(),
+            new CopilotReviewPromptReviewArtifactExportAdapter(),
+        ]);
+
+        const genericExport = await service.exportArtifact(artifact, 'genericMarkdown');
+        const copilotExport = await service.exportArtifact(artifact, 'copilotReviewPrompt');
+
+        assert.ok(genericExport.content.includes('## Diff Files'));
+        assert.ok(genericExport.content.includes('- Diff File ID: diff-file-src-managers-reviewartifactmanager-ts'));
+        assert.ok(genericExport.content.includes('- Hunk ID: diff-file-src-managers-reviewartifactmanager-ts-hunk-1'));
+        assert.ok(genericExport.content.includes('- Target: diffFile:diff-file-src-managers-reviewartifactmanager-ts'));
+        assert.ok(genericExport.content.includes('- Target: diffHunk:diff-file-src-managers-reviewartifactmanager-ts-hunk-1'));
+        assert.ok(copilotExport.content.includes('### Diff Files Under Review'));
+        assert.ok(copilotExport.content.includes('- src/managers/reviewArtifactManager.ts [modified]'));
+        assert.ok(copilotExport.content.includes('- src/test/suite/reviewArtifactExport.test.ts [added]'));
+        assert.ok(copilotExport.content.includes('### 1. Test Gap [high]'));
+        assert.ok(copilotExport.content.includes('- Target: diffHunk:diff-file-src-managers-reviewartifactmanager-ts-hunk-1'));
     });
 });

--- a/src/ui/planReviewPanel.ts
+++ b/src/ui/planReviewPanel.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { ReviewAnnotation, ReviewAnnotationKind, ReviewAnnotationTarget, ReviewArtifact, ReviewArtifactKind } from '../types';
 import { ReviewArtifactManager, type ReviewArtifactExportAdapter } from '../managers';
@@ -11,8 +12,12 @@ interface PlanReviewPanelMessage {
     targetType?: ReviewAnnotationTarget['type'];
     sectionId?: string;
     blockId?: string;
+    diffFileId?: string;
+    diffHunkId?: string;
     lineStart?: number;
     lineEnd?: number;
+    sourcePath?: string;
+    sourceBasePath?: string;
 }
 
 interface AnnotationCategoryOption {
@@ -37,6 +42,15 @@ const AI_RESPONSE_ANNOTATION_CATEGORY_OPTIONS: AnnotationCategoryOption[] = [
     { id: 'risk', label: 'Risk', description: 'Highlight a risky recommendation or omission', kind: 'risk' },
     { id: 'question', label: 'Question', description: 'Capture a clarification question', kind: 'question' },
     { id: 'suggested_replacement', label: 'Suggested Replacement', description: 'Suggest better wording or replacement text', kind: 'maintainability' },
+];
+
+const LOCAL_DIFF_ANNOTATION_CATEGORY_OPTIONS: AnnotationCategoryOption[] = [
+    { id: 'bug_risk', label: 'Bug Risk', description: 'Highlight a risky behavior or logic change', kind: 'risk' },
+    { id: 'test_gap', label: 'Test Gap', description: 'Capture missing or weak test coverage', kind: 'testGap' },
+    { id: 'maintainability', label: 'Maintainability', description: 'Flag readability or complexity concerns', kind: 'maintainability' },
+    { id: 'security', label: 'Security', description: 'Highlight a security-sensitive change', kind: 'risk' },
+    { id: 'performance', label: 'Performance', description: 'Highlight a performance-sensitive change', kind: 'risk' },
+    { id: 'follow_up', label: 'Follow Up', description: 'Capture a deferred follow-up item', kind: 'comment' },
 ];
 
 interface ReviewArtifactUiCopy {
@@ -317,20 +331,26 @@ export class PlanReviewPanel implements vscode.Disposable {
 
     private async openSource(message: PlanReviewPanelMessage): Promise<void> {
         const artifact = await this.getRequiredArtifact();
-        if (!artifact.source.uri?.startsWith('file:')) {
+        const sourceUri = resolveSourceUri(artifact, message);
+        if (!sourceUri) {
             return;
         }
 
-        const document = await vscode.workspace.openTextDocument(vscode.Uri.parse(artifact.source.uri));
-        const editor = await vscode.window.showTextDocument(document, vscode.ViewColumn.One);
-        const startLine = Math.max(0, (message.lineStart ?? 1) - 1);
-        const endLine = Math.min(
-            document.lineCount - 1,
-            Math.max(startLine, (message.lineEnd ?? message.lineStart ?? 1) - 1)
-        );
-        const range = new vscode.Range(startLine, 0, endLine, document.lineAt(endLine).range.end.character);
-        editor.selection = new vscode.Selection(range.start, range.end);
-        editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+        try {
+            const document = await vscode.workspace.openTextDocument(sourceUri);
+            const editor = await vscode.window.showTextDocument(document, vscode.ViewColumn.One);
+            const startLine = Math.max(0, (message.lineStart ?? 1) - 1);
+            const endLine = Math.min(
+                document.lineCount - 1,
+                Math.max(startLine, (message.lineEnd ?? message.lineStart ?? 1) - 1)
+            );
+            const range = new vscode.Range(startLine, 0, endLine, document.lineAt(endLine).range.end.character);
+            editor.selection = new vscode.Selection(range.start, range.end);
+            editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+        } catch (error) {
+            const messageText = error instanceof Error ? error.message : String(error);
+            vscode.window.showWarningMessage(`Unable to open diff source: ${messageText}`);
+        }
     }
 
     private async refresh(): Promise<void> {
@@ -398,6 +418,8 @@ function buildTarget(message: PlanReviewPanelMessage): ReviewAnnotationTarget {
         type: message.targetType ?? 'artifact',
         sectionId: message.sectionId,
         blockId: message.blockId,
+        diffFileId: message.diffFileId,
+        diffHunkId: message.diffHunkId,
         lineStart: message.lineStart,
         lineEnd: message.lineEnd,
     };
@@ -408,7 +430,7 @@ function getAnnotationCategoryOptions(kind: ReviewArtifactKind): AnnotationCateg
         case 'aiResponse':
             return AI_RESPONSE_ANNOTATION_CATEGORY_OPTIONS;
         case 'localDiff':
-            return AI_RESPONSE_ANNOTATION_CATEGORY_OPTIONS;
+            return LOCAL_DIFF_ANNOTATION_CATEGORY_OPTIONS;
         case 'plan':
         default:
             return ANNOTATION_CATEGORY_OPTIONS;
@@ -420,7 +442,7 @@ function getUiCopy(kind: ReviewArtifactKind): ReviewArtifactUiCopy {
 }
 
 async function pickSeverity(categoryId: string): Promise<ReviewAnnotation['severity'] | null | undefined> {
-    if (categoryId === 'approve_note' || categoryId === 'global_comment') {
+    if (categoryId === 'approve_note' || categoryId === 'follow_up' || categoryId === 'global_comment') {
         return null;
     }
 
@@ -450,4 +472,22 @@ function getNonce(): string {
     }
 
     return value;
+}
+
+function resolveSourceUri(artifact: ReviewArtifact, message: PlanReviewPanelMessage): vscode.Uri | undefined {
+    if (message.sourcePath) {
+        const basePath = message.sourceBasePath
+            || (typeof artifact.source.metadata?.repositoryRoot === 'string' ? artifact.source.metadata.repositoryRoot : undefined)
+            || artifact.source.workspaceFolder;
+
+        if (basePath) {
+            return vscode.Uri.file(path.join(basePath, message.sourcePath));
+        }
+    }
+
+    if (artifact.source.uri?.startsWith('file:')) {
+        return vscode.Uri.parse(artifact.source.uri);
+    }
+
+    return undefined;
 }


### PR DESCRIPTION
- Introduced a new command to review local diffs in the extension.
- Implemented LocalDiffReviewService to handle the creation of review artifacts from workspace diffs.
- Added UI components to support local diff reviews, including new annotation categories.
- Enhanced existing review artifact export functionality to include local diff artifacts.
- Created tests for local diff review commands and service to ensure proper functionality.